### PR TITLE
Improve profiling and threading documentation

### DIFF
--- a/julia-perf/SKILL.md
+++ b/julia-perf/SKILL.md
@@ -47,6 +47,7 @@ julia --track-allocation=user -e 'using MyPkg; my_function(args); Profile.clear_
 - **[Structs & Dispatch](references/structs-dispatch.md)** — Concrete fields, parametric types, Val
 - **[Memory & Arrays](references/memory-arrays.md)** — Pre-allocation, views, column-major, broadcasting
 - **[Annotations & Tweaks](references/annotations-tweaks.md)** — @inbounds, @fastmath, @simd, misc tips
+- **[Fast Loop Libraries](references/fast-loop-libraries.md)** — LoopVectorization, FastBroadcast, and Strided
 - **[Profiling & Diagnosis](references/profiling.md)** — @code_warntype, profiling, allocation tracking
 
 ## Related Skills

--- a/julia-perf/references/fast-loop-libraries.md
+++ b/julia-perf/references/fast-loop-libraries.md
@@ -1,0 +1,129 @@
+# Fast Loop and Array Libraries
+
+For extremely hot, compute-bound code, Julia's standard abstractions (like broadcast or native array views) can sometimes leave performance on the table due to compiler optimization limits or memory access patterns. The following ecosystem packages provide highly optimized macro-based alternatives.
+
+## LoopVectorization.jl (`@turbo`)
+
+`LoopVectorization.jl` transforms standard `for` loops and array operations into highly optimized SIMD (Single Instruction, Multiple Data) instructions, utilizing AVX-512, AVX2, or NEON depending on the architecture. 
+
+While LLVM/Julia natively generates optimal SIMD instructions for the main body of a loop, it struggles significantly with loop remainders (the "tails" of the array that don't fit perfectly into the SIMD register width). LoopVectorization's greatest performance benefit comes from handling these tails far more efficiently than standard `@simd`.
+
+### Usage and Examples
+Prefix a `for` loop or broadcast statement with `@turbo`:
+
+```julia
+function mydotavx(a, b)
+    s = 0.0
+    @turbo for i ∈ eachindex(a,b)
+        s += a[i]*b[i]
+    end
+    s
+end
+```
+
+When dealing with arrays that have a leading dimension of size 1 (i.e., broadcasting across rows), you can wrap them in `LowDimArray` so the macro can optimize accordingly:
+```julia
+using LoopVectorization
+ldad = LowDimArray{(false,true,true)}(d)
+@turbo @. E = exp(A - b' + ldad) * c
+```
+
+### Requirements & Limitations (Nasal Demons Warning!)
+Misusing LoopVectorization can have severe consequences. Like `@inbounds`, misusing it can lead to segfaults and memory corruption. **You must guarantee the following when using `@turbo`:**
+
+1. **No Bounds Checking**: `@turbo` does not perform any bounds checking. You must ensure you are not indexing an array out of bounds.
+2. **No Empty Iteration Spaces**: Iterating over an empty loop (such as `for i ∈ eachindex(Float64[])`) is undefined behavior and will likely result in out-of-bounds memory accesses.
+3. **No Specific Execution Order**: `@turbo` can and will re-order operations and loops inside its scope. The code's correctness cannot depend on a particular order (e.g., you cannot implement `cumsum` with `@turbo`).
+4. **No Multiple Same-Level Loops**: You are not using multiple loops at the same level within nested loops.
+5. **Iteration Space**: It currently only supports rectangular iteration spaces (not triangular or ragged). Inner loop iterations cannot be a function of outer loop variables.
+6. **No Branches/Allocations**: Loop bodies cannot contain branching (`if` statements) or allocations.
+7. **No kwargs**: `@turbo` does not support passing kwargs to function calls inside its block (e.g., `@turbo round.(A; digits=3)` throws a `TypeError`). Work around this by wrapping the call in an anonymous function or struct beforehand:
+   ```julia
+   struct KwargCall{F,T} f::F; x::T end
+   @inline (f::KwargCall)(args...) = f.f(args...; f.x...)
+   f = KwargCall(round, (digits = 3,));
+   @turbo f.(rand(10))
+   ```
+
+### The StructArray Trick (Complex Numbers & Structs)
+Because `@turbo` leverages low-level knowledge of how primitive types (like `Float64` or `Int`) are handled by CPU registers, it **cannot** natively handle arrays of structs (such as `Array{Complex{Float64}}`).
+To vectorize code involving complex numbers or custom numeric structs, use **`StructArrays.jl`** to transform your Array-of-Structs (AoS) into a Struct-of-Arrays (SoA). 
+```julia
+using StructArrays
+
+# Create a StructArray which separates the real and imaginary parts into their own arrays:
+A = StructArray(randn(ComplexF64, M, K))
+
+# You can now apply @turbo on the underlying arrays of primitives independently:
+@turbo for i in eachindex(A)
+    A.re[i] += 1.0
+    A.im[i] -= 1.0
+end
+```
+This pattern extends to other numeric structs like dual numbers or `DoubleFloats`.
+
+### Vectorized Convenience Functions
+LoopVectorization exports highly optimized mapping alternatives:
+- **`vmap` / `vmap!`**: Directly vectorized (SIMD) versions of `map` and `map!`.
+- **`vmapnt` / `vmapnt!`**: Like `vmap`, but uses **non-temporal (streaming) stores** when writing to the destination array. This explicitly prevents the CPU from pulling the destination memory into the cache hierarchy, preserving cache space for other data. It yields major performance increases for massive arrays whose written values won't be read back again soon.
+- **`vmapntt!`**: Multithreaded + non-temporal `map!`.
+
+*(Threading note: Can be multithreaded using `@tturbo` or `@turbo thread=true` (or `thread=8`)).*
+
+---
+
+## FastBroadcast.jl (`@..`)
+
+`FastBroadcast.jl` exports `@..`, a drop-in replacement for standard broadcast (`@.`) that compiles the expression directly into simple `for` loops that are significantly easier for the LLVM compiler to optimize.
+
+### Usage and Examples
+```julia
+using FastBroadcast
+
+function fast_foo9(a, b, c, d, e, f, g, h, i)
+    @.. a = b + 0.1 * (0.2c + 0.3d + 0.4e + 0.5f + 0.6g + 0.6h + 0.6i)
+    nothing
+end
+```
+
+### Performance Benefits
+- **Avoids Temporaries**: Standard broadcasting can sometimes trigger intermediate allocations when evaluating complex, deeply nested expressions with many arguments. `@..` reliably fuses the entire expression into a single allocation-free loop.
+- **Faster Compilation**: Because it directly generates a `for` loop instead of deeply nested internal broadcast machinery types, the time-to-first-execution (TTFX) and compiler latency are drastically reduced.
+
+*(Threading note: Can be multithreaded using `@.. thread=true`).*
+
+---
+
+## Strided.jl (`@strided`)
+
+`Strided.jl` provides cache-friendly, highly optimized manipulations for arrays with arbitrary strides. While Julia's Base operations assume column-major contiguous memory, `Strided.jl` makes no assumptions (e.g., stride 1 along the first dimension, or monotonically increasing strides) and excels when memory is non-contiguous (e.g., transposed arrays, reshaped views).
+
+Currently, Strided.jl methods are restricted to array data in main memory and do not support GPUs.
+
+### Usage and Examples
+Wrap operations like broadcasts, reductions, or `permutedims` in `@strided`:
+
+```julia
+using Strided
+
+A = randn(4000, 4000); B = similar(A);
+
+# Cache misses on A' make Base slow (e.g. 145 ms)
+B .= (A .+ A') ./ 2
+
+# Strided reorganizes memory access to be cache-friendly (e.g. 56 ms)
+@strided B .= (A .+ A') ./ 2
+
+# Massive improvements on non-contiguous array multiplication (2.4 ms -> 1.4 ms)
+@strided B .= 3 .* A'
+
+# Multidimensional permutations are much faster (5.2 ms -> 2.2 ms)
+@strided permutedims!(B, A, (4,3,2,1))
+```
+
+### Key Functions and Configuration
+- **`@strided`**: The main macro. Reorganizes the memory access pattern of the enclosed expression to avoid massive performance cliffs associated with non-contiguous memory access.
+- **`StridedView(A)`**: The foundational structured type (provided by `StridedViews.jl`) that wraps a contiguous array. It is device-agnostic and guarantees downstream functions utilize cache-aware algorithms.
+- **`sreshape` / `sview`**: Strided-specific equivalents to `reshape` and `view` that ensure the result remains properly typed for Strided's algorithms without unnecessary allocations.
+
+*(Threading note: Can be multithreaded; `@strided` enables it automatically for large arrays).*

--- a/julia-perf/references/profiling.md
+++ b/julia-perf/references/profiling.md
@@ -2,6 +2,11 @@
 
 Source: https://docs.julialang.org/en/v1/manual/performance-tips/
 
+Agents cannot use interactive viewers, GUI visualizers (ProfileView, PProf), or
+REPL displays. Always export profile data to flat `.txt` files (`format=:flat`,
+wide `displaysize`) or parse `Profile.fetch()` / `Profile.Allocs.fetch()`
+programmatically.
+
 ## Step-by-Step Diagnosis
 
 ### 1. Benchmark with @time / @btime
@@ -43,42 +48,87 @@ Common causes of instability:
 | Struct field is abstract | Parameterize the struct |
 | Captured closure variable | Use `let` block or type annotation |
 
-### 3. Profile Execution Time
+### 3. CPU Sampling Profiler (`Profile.@profile`)
+
+Identifies the most time-consuming operations in compute-bound code. Export a
+flat, tabular summary to a file for parsing:
 
 ```julia
 using Profile
 
-@profile my_function(args)
-Profile.print(noisefloor=2.0)  # suppress noise
+my_function(args)         # 1. force compilation first
+Profile.clear()           # 2. clear stale samples
 
-# Visual profilers
-using ProfileView
-@profview my_function(args)
+@profile my_function(args)  # 3. collect
 
-# Flame graph
-using PProf
-@profile my_function(args)
-pprof()
+# 4. export flat table — wide displaysize prevents truncation
+open("profile_results.txt", "w") do io
+    Profile.print(IOContext(io, :displaysize => (24, 1000)), format=:flat)
+end
 ```
 
-### 4. Track Allocations
+Then read `profile_results.txt` and find the functions with the highest sample
+counts.
 
-```bash
-julia --track-allocation=user script.jl
-```
+**Hierarchical (JSON) export.** For a structured call tree instead of a flat
+list, build a `FlameGraphs.flamegraph()`, map its nodes into plain `Dict`s, and
+write them with `JSON.json(dict)` to a file for programmatic analysis.
+
+### 4. Wall-time Profiler (`Profile.@profile_walltime`)
+
+Samples all tasks regardless of scheduling state. Use it for IO-heavy work or
+to diagnose contention on synchronization primitives (tasks waiting on
+`Channel`s or locks).
 
 ```julia
-# In script.jl:
-using MyPackage
-my_function(args)                # warm up (compile)
-Profile.clear_malloc_data()      # reset counters
-my_function(args)                # measure
+using Profile
+
+my_function(args)         # force compilation
+Profile.clear()
+
+@profile_walltime my_function(args)
+
+open("walltime_profile_results.txt", "w") do io
+    Profile.print(IOContext(io, :displaysize => (24, 1000)), format=:flat)
+end
 ```
 
-This produces `.mem` files alongside source files showing bytes allocated per
-line.
+Extremely short-lived tasks may appear as `failed_to_sample_task_fun` or
+`failed_to_stop_thread_fun`.
 
-### 5. Automated Analysis with JET.jl
+### 5. Track Allocations
+
+The allocation profiler records the stack trace and type of each allocation and
+returns natively structured data:
+
+```julia
+using Profile
+
+my_function(args)         # force compilation
+Profile.Allocs.clear()
+
+# sample_rate: 0.01 = 1%, 1.0 = every allocation. Aim for 1k–10k samples.
+Profile.Allocs.@profile sample_rate=0.01 my_function(args)
+
+prof = Profile.Allocs.fetch()
+sort!(prof.allocs, by = a -> a.size, rev = true)
+
+open("allocation_results.txt", "w") do io
+    for alloc in prof.allocs[1:min(10, end)]
+        println(io, "Size: $(alloc.size), Type: $(alloc.type)")
+        # alloc.stacktrace holds the frames if needed
+    end
+end
+```
+
+Samples are drawn uniformly across allocations (not weighted by size) unless
+`sample_rate = 1`. For a coarse view, `GC.enable_logging(true)` logs GC events
+to `stderr`. Line-level data is also available via
+`julia --track-allocation=user script.jl`, which writes `.mem` files next to
+each source file (warm up once, then `Profile.clear_malloc_data()` before the
+measured call).
+
+### 6. Automated Analysis with JET.jl
 
 ```julia
 using JET
@@ -95,7 +145,7 @@ errors without running the code.
 Run these in order on any slow function:
 
 ```julia
-using BenchmarkTools, JET
+using BenchmarkTools, JET, Profile
 
 # 1. How slow is it?
 @btime target_function($args)
@@ -106,8 +156,12 @@ using BenchmarkTools, JET
 # 3. Automated check
 @report_opt target_function(args)
 
-# 4. Where is time spent?
-@profview target_function(args)   # requires ProfileView
+# 4. Where is time spent? (export to file, then read it)
+target_function(args); Profile.clear()
+@profile target_function(args)
+open("profile_results.txt", "w") do io
+    Profile.print(IOContext(io, :displaysize => (24, 1000)), format=:flat)
+end
 ```
 
 ## Common Patterns and Fixes
@@ -171,3 +225,13 @@ function process()
     sum(data::Vector{Float64})
 end
 ```
+
+## General Best Practices
+
+1. **Force JIT compilation** — run the function once before profiling, or the
+   profile captures the compiler instead of the target code.
+2. **Clear buffers** — `Profile.clear()` / `Profile.Allocs.clear()` before each
+   collection to avoid merging with stale data.
+3. **Export, don't display** — never use interactive viewers, GUI visualizers,
+   or REPL prints. Write wide `.txt` files (`format=:flat`), parse
+   `fetch()` results directly, or export JSON.

--- a/julia-threads/SKILL.md
+++ b/julia-threads/SKILL.md
@@ -28,9 +28,14 @@ Use threadpools for responsiveness and interactive tasks.
 
 ## Pick the Execution Primitive
 
-- Use `Threads.@threads` for parallel loops over iteration spaces.
+- Use `Threads.@threads [schedule]` for parallel loops over iteration spaces.
+  - `:dynamic` (default): Distributes chunks dynamically. Best for uniform workloads.
+  - `:greedy` (Julia 1.11+): Tasks greedily take the next value. Excellent for non-uniform workloads and non-indexable iterators.
+  - `:static`: Divides iterations equally with exactly one task per thread. Discouraged in library code as it cannot be nested or called outside thread 1.
 - Use `Threads.@spawn` for task-based parallel decomposition.
 - Use `@spawn :interactive ...` for latency-sensitive tasks.
+- Use `Polyester.@batch` for lightweight multithreaded loops with significantly lower task-spawning overhead than `@threads`, making it ideal for tight loops.
+- Leverage ecosystem packages built on Polyester for low-overhead multithreading: `Strided.jl` (multithreaded array views), `FastBroadcast.jl` (`@.. thread=true` for non-allocating parallel broadcast), and `LoopVectorization.jl` (`@tturbo` for multithreaded SIMD vectorization).
 
 For reduction-style work, avoid shared mutable accumulators; split work into independent chunks and combine results after `fetch`.
 
@@ -41,6 +46,10 @@ Treat race freedom as a hard requirement:
 - Prefer `Base.Lockable` to bind lock + protected object.
 - Use `Threads.Atomic` / `atomic_*` for primitive shared counters and similar patterns.
 - Use per-field atomics (`@atomic`, `@atomicswap`, `@atomicreplace`, `@atomiconce`) when field-level ordering is required.
+
+## Numeric Libraries (BLAS, FFTW, MKL)
+
+When mixing Julia's native multithreading with external threaded libraries, you must manually manage thread counts to avoid **oversubscription**. If calling these libraries inside a natively threaded region, set their thread count to `1` (e.g., `BLAS.set_num_threads(1)`).
 
 ## Handle Migration and Runtime Caveats
 
@@ -53,6 +62,8 @@ Treat race freedom as a hard requirement:
 ## Reference
 
 - `references/threading-patterns.md` - thread setup, safety, and synchronization patterns
+- `references/polyester.md` - lightweight threading with Polyester.jl and related ecosystem packages
+- `references/numeric-libraries.md` - managing thread counts in BLAS, MKL, and FFTW
 
 ## Related Skills
 

--- a/julia-threads/references/numeric-libraries.md
+++ b/julia-threads/references/numeric-libraries.md
@@ -1,0 +1,23 @@
+# Threading in External Libraries
+
+When mixing Julia's native multithreading with external threaded libraries (like BLAS, LAPACK, or FFTW), you must carefully manage thread counts. Failing to do so can lead to **oversubscription**, where `N` Julia threads each spawn `N` external threads, resulting in `N^2` threads competing for `N` CPU cores and causing severe performance degradation.
+
+## General Rule
+If you are calling an externally threaded function *inside* a natively threaded Julia region (e.g., inside `@threads`, `@spawn`, or `@batch`), you **must** disable its internal threading by setting its thread count to `1` beforehand.
+
+## BLAS
+Julia uses OpenBLAS by default for dense linear algebra.
+- **Check threads**: `LinearAlgebra.BLAS.get_num_threads()`
+- **Set threads**: `LinearAlgebra.BLAS.set_num_threads(n)`
+
+## MKL.jl (Intel Math Kernel Library)
+When using MKL instead of OpenBLAS, `BLAS.set_num_threads()` only configures the BLAS routines. However, MKL also accelerates LAPACK and other domains.
+- **Check global threads**: `MKL.get_num_threads()`
+- **Set global threads**: `MKL.set_num_threads(n)`
+- **Note**: Using `MKL.set_num_threads(n)` is the only way to correctly set the number of threads for MKL's LAPACK routines natively (see [MKL.jl PR #180](https://github.com/JuliaLinearAlgebra/MKL.jl/pull/180)).
+
+## FFTW.jl
+FFTW provides fast Fourier transforms and has its own threading engine.
+- **Check threads**: `FFTW.get_num_threads()`
+- **Set threads**: `FFTW.set_num_threads(n)`
+- **Critical Note**: The FFTW threading policy is strictly fixed when a plan is created. You cannot change the number of threads for an existing FFTW plan. If you need both single-threaded and multi-threaded FFTs, you must create two separate plans with the respective thread counts set prior to their creation.

--- a/julia-threads/references/polyester.md
+++ b/julia-threads/references/polyester.md
@@ -1,0 +1,84 @@
+# Lightweight Threading with Polyester.jl
+
+Julia's standard `Base.Threads.@threads` incurs a small but non-trivial overhead when scheduling tasks. For tight loops that complete very quickly, this task-spawning overhead can dominate execution time, neutralizing the benefits of multithreading. 
+
+`Polyester.jl` provides `@batch`, an alternative that implements lightweight, low-overhead threading. It achieves this static scheduling by keeping a dedicated static pool of threads awake and synchronizing them directly using atomics, bypassing Julia's standard task scheduler entirely.
+
+## Using `@batch`
+
+Use `@batch for i in ...` instead of `@threads` for inner loops where iteration bodies are extremely fast.
+
+### Crucial Caveats
+- **Slicing creates views**: `Polyester.@batch` moves arrays to threads by turning them into `StrideArraysCore.PtrArray`s. This means that under a `@batch` loop, array slices will automatically create `view`s by default! You may want to start Julia with `--check-bounds=yes` while debugging.
+- **No thread pinning**: Polyester uses regular Julia threads, governed by `JULIA_NUM_THREADS`. It does **not** pin threads to specific CPU-cores. To guarantee threads run on specific cores, use a tool like `ThreadPinning.jl`.
+
+### Configuration and Keywords
+
+#### `per=cores` vs `per=threads`
+By default, `@batch` uses `per=cores`, meaning it limits execution to up to 1 thread per physical CPU core (e.g., skipping hyperthreads). This default exists because LoopVectorization.jl (a major Polyester consumer) performs optimally with 1 thread per physical core. If you explicitly want to utilize all logical threads, use `@batch per=threads for ...`.
+
+#### `minbatch`
+The `minbatch` argument allows you to specify a minimum number of loop iterations per thread, effectively capping the number of threads spawned for small arrays. For example, `minbatch=n` means it will use at most `number_of_iterations ÷ n` threads. 
+```julia
+# With 10,000 items, minbatch=2500 ensures only 4 threads are used.
+@batch minbatch=2500 for i in eachindex(y, x)
+    y[i] = a * x[i] + y[i]
+end
+```
+
+#### `threadlocal`
+You can define local storage for each thread without incurring allocations. Polyester will return a vector containing each of the local storages at the end of the loop block.
+```julia
+# Optionally define the type (e.g. ::Float16)
+let
+    @batch threadlocal=rand(10:99)::Float16 for i in 1:100
+        # Use `threadlocal` safely inside the loop
+        threadlocal += i
+    end
+    println(threadlocal) # e.g. Float16[83.0, 90.0, 27.0, 65.0]
+end
+```
+
+#### `reduction`
+The `reduction` keyword enables zero-allocation reductions of an already initialized `isbits` variable. It supports tuples of associative operations with their starting variables.
+```julia
+y1 = 0
+y2 = 1
+@batch reduction=((+, y1), (*, y2)) for i in 1:9
+    y1 += i
+    y2 *= i
+end
+```
+
+### Disabling for Nested Parallelism
+
+When running many repetitions of a Polyester-multithreaded function (e.g., in an embarrassingly parallel problem where an outer loop repeatedly executes an inner function that contains `@batch`), it is highly beneficial to disable Polyester's inner threading to avoid task oversubscription.
+
+This is done using the `Polyester.disable_polyester_threads()` context manager. 
+**Crucial Rule**: Call this manager *once* outside the `Base.Threads.@threads` loop, not inside it, to avoid unnecessary overhead.
+
+```julia
+# DO THIS: Fast!
+Polyester.disable_polyester_threads() do
+    @threads for i in 1:N
+        func_with_batch()
+    end
+end
+
+# DO NOT DO THIS: Unnecessary overhead inside the loop
+@threads for i in 1:N
+    Polyester.disable_polyester_threads() do
+        func_with_batch()
+    end
+end
+```
+
+---
+
+## Ecosystem Packages Built on Polyester
+
+These packages provide high-level APIs that use Polyester under the hood for low-overhead multithreading. 
+
+- **FastBroadcast.jl**: Provides `@..` for parallel broadcasts. Note that threading is **not** enabled by default; use `@.. thread=true` to enable it. *Warning: on small arrays, `@.. thread=true` can be much slower than standard `@..` due to task overhead. Always benchmark!*
+- **Strided.jl**: Provides `@strided` to easily parallelize array operations, broadcasts, and `permutedims` over strided arrays. Strided automatically decides whether threading is beneficial based on the array size, or you can manually control it via `Strided.set_num_threads(n)`.
+- **LoopVectorization.jl**: Provides `@tturbo` (or `@turbo thread=true` / `@turbo thread=n`) to combine SIMD vectorization with lightweight Polyester-style multithreading.

--- a/julia-threads/references/threading-patterns.md
+++ b/julia-threads/references/threading-patterns.md
@@ -16,13 +16,18 @@ GC thread configuration:
 
 ## Data Parallel Loops
 
-Use `Threads.@threads` on loop iteration spaces:
+Use `Threads.@threads [schedule]` on loop iteration spaces:
 
 ```julia
 Threads.@threads for i in eachindex(a)
     a[i] = f(a[i])
 end
 ```
+
+### Scheduling Options
+- **`:dynamic` (default)**: Distributes iterations dynamically to available worker threads. Each task processes contiguous regions. This is typically the most efficient option for uniform workloads.
+- **`:greedy` (Julia 1.11+)**: Spawns up to `threadpoolsize()` tasks, each greedily taking the next value from the iterator as soon as they finish the previous one. Excellent for workloads where individual iterations have highly non-uniform runtimes or when the iterator only supports `iterate` (no indexing).
+- **`:static`**: Creates exactly one task per thread and divides the iterations equally among them. Note that `threadid()` is constant within an iteration. *Warning*: Discouraged in library functions as it cannot be nested and throws an error if called from a thread other than 1.
 
 `@threads` does not do reductions automatically; implement reduction safely with chunk-local state and final aggregation.
 


### PR DESCRIPTION
Hi @Krastanov,
thanks for this repo, I'm looking for such collection for quite some time! I revised some of them which are useful for my work, and I found two areas where felt the urge to make modifications: profiling and threading

- julia-perf/references/profiling.md shouldn't recommend GUI tools, and focus only on methods that produce textual output
- I missed some performance libraries I frequently use and I think they are also very common in the community: LoopVectorization and Polyester. FastBroadcast and Strided are also proved to be useful for me, and they are good companions for LoopVectorization and Polyester, so it seemed natural to include them. I created julia-perf/references/fast-loop-libraries.md and julia-threads/references/polyester.md to describe these libraries.
- Previously I spent quite some time to debug why my multithreaded code performed worse the the single-threaded one, and it turned out that it was a multithreaded FFTW plan called from a threaded loop... So I also added julia-threads/references/numeric-libraries.md to talk about the optionally threaded numeric libraries (OpenBLAS, FFTW, MKL) that don't compose well with Julia threading.
- I also missed description of scheduling options for @threads.
