### PR TITLE
Add document repository V-model skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Julia Agent Skills
+# Agent Skills
 
-Five task-oriented skills for Julia work. Each `SKILL.md` is a small router;
-details and examples live in references that are loaded only for the current
-task.
+Six task-oriented skills: five for Julia work and one for agent-facing
+repository documentation. Each `SKILL.md` is a small router; details and
+examples live in references that are loaded only for the current task.
 
 | Skill | Scope |
 | --- | --- |
@@ -11,6 +11,7 @@ task.
 | [`orchestrate-julia-workloads`](orchestrate-julia-workloads/) | Tasks, channels, threads, synchronization, native-library thread control, and subprocesses |
 | [`handle-julia-data`](handle-julia-data/) | DataFrames/Tables workflows, delimited data, TOML/YAML configuration, and table reports |
 | [`build-julia-interfaces`](build-julia-interfaces/) | Scripts, Pkg apps, Comonicon CLIs, Term output/TUIs, and Makie recipes |
+| [`document-repository-v-model`](document-repository-v-model/) | Progressive repository guidance, structured V-model specifications, traceability, review, and compaction |
 
 ## Design
 

--- a/document-repository-v-model/SKILL.md
+++ b/document-repository-v-model/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: document-repository-v-model
+description: Build, migrate, audit, review, update, and compact agent-facing repository documentation with nested AGENTS.md routers, selectively loaded Diátaxis-style .agents context, structured V-model specifications, and bidirectional verification traceability. Use when creating documentation for a new or existing repository, migrating a monolithic AGENTS.md, defining or auditing V-model traceability, interviewing developers to recover intended behavior, adding nested AGENTS.md files, organizing agent context, reviewing .agents consistency, or compacting stale and duplicated repository context.
+---
+
+# Document Repository V-Model
+
+Create a small, navigable documentation system that separates normative product
+specification from implementation decisions. Treat the V-model as a general repository
+profile, not as a claim of NASA, FDA, ECSS, or V-Modell XT compliance.
+
+## Start
+
+1. Read every applicable repository instruction before inspecting or changing files.
+2. Determine the repository boundary, worktree rules, code roots, existing documentation,
+   and whether the request is creation, migration, review, or update.
+3. Preserve useful material and user changes. Do not infer intended behavior from code or
+   tests alone.
+4. Keep normative behavior under `.agents/v-model/`; keep implementation-facing
+   learning, task, reference, and explanation material in `.agents/context/`.
+5. Load only the references needed for the selected workflow. Never recursively load the
+   entire `.agents/` tree.
+
+## Select a Workflow
+
+- For a new repository, read [discovery and interviews](references/discovery-and-interviews.md),
+  interview in short rounds, confirm stakeholder outcomes before deriving requirements,
+  then add context and routers only as real boundaries emerge.
+- For an existing repository or monolithic guide, read
+  [discovery and interviews](references/discovery-and-interviews.md) and
+  [repository layout](references/repository-layout.md). Discover evidence read-only,
+  classify observed behavior, and baseline only confirmed intent.
+- For a consistency review or compaction, read
+  [review and compaction](references/review-and-compaction.md). Update canonical content
+  before shortening routers, then recheck links, traceability, and meaning.
+- For a feature or release update, run a mini-V: revise affected outcomes and requirements,
+  update contracts and verification actions, record implementation decisions separately,
+  and assess regression impact.
+
+Read [V-model and traceability](references/v-model-and-traceability.md) whenever creating,
+changing, or auditing specification records. Read
+[agent context documentation](references/agent-context-documentation.md) only when
+creating, migrating, splitting, reviewing, or compacting `.agents/context/`; skip it for
+router-only or V-model-only work. Read
+[subagent playbooks](references/subagent-playbooks.md) only when delegation is permitted
+and risk, scale, or requested independence justifies separate investigators or reviewers.
+
+## Build the Documentation
+
+Use [repository layout](references/repository-layout.md) as the topology contract. Start
+from the files under `assets/templates/` selectively; do not copy a template for a
+boundary or record that does not exist. Replace every template token and adapt commands
+to repository evidence.
+
+Keep each `AGENTS.md` to inherited-scope deltas, local commands and rules, and links that
+say when deeper context should be opened. Put detailed implementation-facing material in
+selectively routed context files. Use stable specification and verification IDs exactly
+as defined by the V-model reference, with objective pass criteria and many-to-many
+reverse links.
+
+When intent is uncertain, preserve the uncertainty explicitly and ask the developer only
+about intent or genuine tradeoffs. Do not silently choose code, tests, or old prose as
+the authority. Do not write an unconditional normative claim when repository evidence
+already contains a counterexample.
+
+## Validate
+
+Run the dependency-free, read-only linter from this skill directory:
+
+```text
+python3 scripts/lint_repository_docs.py REPOSITORY \
+  [--source-root PATH ...] [--json] [--fail-on-warn]
+```
+
+Use repeated `--source-root` options for nonstandard or polyglot layouts. Without an
+option, the linter uses `src` only when it exists. Resolve every integrity error. Treat
+warnings proportionally, but remove avoidable router-size and duplication warnings.
+
+Then review semantics the linter cannot prove:
+
+1. Confirm each normative statement represents intended behavior.
+2. Confirm specifications remain understandable without decision documents.
+3. Try to falsify universal claims with boundary, malformed, and fallback cases.
+4. Confirm every clause in an action’s pass criterion is supported by the cited evidence
+   and that its status is no stronger than that evidence.
+5. Confirm evidence references are durable and statuses are current.
+6. Confirm each context leaf has one dominant need and routers load only relevant detail.
+7. Confirm no source files changed when the task was documentation-only.
+
+## Report
+
+Report the selected profile, code roots, files created, moved, or retired, unresolved
+intent or traceability gaps, linter result, semantic review result, developer
+confirmations still needed, and any checks not run.

--- a/document-repository-v-model/agents/openai.yaml
+++ b/document-repository-v-model/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Document Repository V-Model"
+  short_description: "Build and audit repository documentation"
+  default_prompt: "Use $document-repository-v-model to structure and validate this repository’s agent-facing documentation."

--- a/document-repository-v-model/assets/templates/AGENTS-root.md
+++ b/document-repository-v-model/assets/templates/AGENTS-root.md
@@ -1,0 +1,36 @@
+# {{REPOSITORY_NAME}} Repository Guidance
+
+## Scope
+
+This file applies repository-wide. More specific `AGENTS.md` files add or override
+guidance for their directory subtrees.
+
+## Start here
+
+- Open [the repository context index](.agents/index.md) to choose only the topic needed
+  for the current task. Do not read `.agents/` recursively.
+- Open [the V-model index](.agents/v-model/index.md) when changing observable behavior,
+  interfaces, acceptance criteria, or verification evidence.
+- Read the closest nested `AGENTS.md` before editing within a code root or subsystem.
+
+## Code roots
+
+- `{{CODE_ROOT}}/` — {{CODE_ROOT_PURPOSE}}. Follow
+  [`{{CODE_ROOT}}/AGENTS.md`]({{CODE_ROOT}}/AGENTS.md).
+
+## Commands
+
+- Setup: `{{SETUP_COMMAND}}`
+- Focused check: `{{FOCUSED_CHECK_COMMAND}}`
+- Full validation: `{{FULL_VALIDATION_COMMAND}}`
+
+## Repository rules
+
+- {{REPOSITORY_WIDE_RULE}}
+- Preserve unrelated user changes and follow the repository’s worktree policy.
+- Update canonical specification or context before changing a router that links to it.
+
+## Handoff
+
+Report changed behavior and documentation, checks run, unresolved specification or
+evidence gaps, and checks not run.

--- a/document-repository-v-model/assets/templates/AGENTS-source.md
+++ b/document-repository-v-model/assets/templates/AGENTS-source.md
@@ -1,0 +1,22 @@
+# {{BOUNDARY_NAME}} Guidance
+
+## Scope
+
+This file applies to `{{BOUNDARY_PATH}}/` and supplements inherited repository guidance.
+
+## Open selectively
+
+- Open [{{CONTEXT_TOPIC_NAME}}]({{RELATIVE_AGENTS_PATH}}/context/{{CONTEXT_TOPIC_FILE}})
+  when {{OPEN_CONDITION}}.
+- Do not open that topic when {{AVOID_CONDITION}}.
+- Open [the V-model]({{RELATIVE_AGENTS_PATH}}/v-model/index.md) when changing observable
+  behavior or evidence for this boundary.
+
+## Local commands
+
+- Focused check: `{{LOCAL_CHECK_COMMAND}}`
+
+## Local rules
+
+- {{LOCAL_RULE}}
+- Keep boundary-specific detail in the linked context topic rather than this router.

--- a/document-repository-v-model/assets/templates/context-topic.md
+++ b/document-repository-v-model/assets/templates/context-topic.md
@@ -1,0 +1,20 @@
+# {{TOPIC_TITLE}}
+
+- **Context need:** {{CONTEXT_NEED}}
+- **Open when:** {{OPEN_CONDITION}}
+- **Do not open when:** {{AVOID_CONDITION}}
+- **Related specification IDs:** {{SPECIFICATION_IDS}}
+- **Review when:** {{REVIEW_TRIGGER}}
+
+## {{NEED_SPECIFIC_HEADING}}
+
+{{NEED_SHAPED_BODY}}
+
+## Anchors
+
+- **Source:** [`{{SOURCE_PATH}}`]({{SOURCE_LINK}}) — {{SOURCE_ANCHOR_PURPOSE}}
+- **Test:** [`{{TEST_PATH}}`]({{TEST_LINK}}) — {{TEST_ANCHOR_PURPOSE}}
+
+## Unresolved questions
+
+- {{UNRESOLVED_QUESTION_OR_NONE}}

--- a/document-repository-v-model/assets/templates/v-model/01-stakeholder-outcomes.md
+++ b/document-repository-v-model/assets/templates/v-model/01-stakeholder-outcomes.md
@@ -1,0 +1,20 @@
+# Stakeholder Outcomes
+
+Describe intended outcomes in operational language. Exclude implementation terminology.
+
+## STK-001 — {{OUTCOME_TITLE}}
+
+- **Normative statement:** {{ACTOR_AND_INTENDED_OUTCOME}}
+- **Parents:** None
+- **Acceptance criterion:** {{OPERATIONAL_SUCCESS_MEASURE}}
+- **Verification:** ACC-001 (demonstration)
+- **Origin / risk:** {{ORIGIN_AND_RISK}}
+- **Context:** None
+
+### Operational scenarios
+
+- {{SCENARIO}}
+
+### Explicit exclusions
+
+- {{EXCLUSION}}

--- a/document-repository-v-model/assets/templates/v-model/02-system-requirements.md
+++ b/document-repository-v-model/assets/templates/v-model/02-system-requirements.md
@@ -1,0 +1,12 @@
+# System Requirements
+
+Specify externally observable behavior, quality attributes, constraints, and boundaries.
+
+## SYS-001 — {{SYSTEM_REQUIREMENT_TITLE}}
+
+- **Normative statement:** {{OBSERVABLE_NORMATIVE_BEHAVIOR}}
+- **Parents:** STK-001
+- **Acceptance criterion:** {{OBJECTIVE_SYSTEM_CRITERION}}
+- **Verification:** SYSV-001 (test)
+- **Origin / risk:** {{ORIGIN_AND_RISK}}
+- **Context:** None

--- a/document-repository-v-model/assets/templates/v-model/03-subsystem-contracts.md
+++ b/document-repository-v-model/assets/templates/v-model/03-subsystem-contracts.md
@@ -1,0 +1,19 @@
+# Subsystem and Interface Contracts
+
+Specify logical responsibilities and boundary semantics without fixing package topology.
+
+## SUB-001 — {{SUBSYSTEM_CONTRACT_TITLE}}
+
+- **Normative statement:** {{LOGICAL_BOUNDARY_CONTRACT}}
+- **Parents:** SYS-001
+- **Acceptance criterion:** {{OBJECTIVE_INTEGRATION_CRITERION}}
+- **Verification:** INTV-001 (test)
+- **Origin / risk:** {{ORIGIN_AND_RISK}}
+- **Context:** [{{CONTEXT_TOPIC_TITLE}}]({{CONTEXT_TOPIC_LINK}})
+
+### Boundary semantics
+
+- **Inputs:** {{INPUT_SEMANTICS}}
+- **Outputs:** {{OUTPUT_SEMANTICS}}
+- **State:** {{STATE_SEMANTICS}}
+- **Errors:** {{ERROR_SEMANTICS}}

--- a/document-repository-v-model/assets/templates/v-model/04-component-contracts.md
+++ b/document-repository-v-model/assets/templates/v-model/04-component-contracts.md
@@ -1,0 +1,13 @@
+# Component Contracts
+
+Record only non-obvious behavior, invariants, pre/postconditions, or resource budgets
+needed for implementation and verification.
+
+## CMP-001 — {{COMPONENT_CONTRACT_TITLE}}
+
+- **Normative statement:** {{NON_OBVIOUS_COMPONENT_CONTRACT}}
+- **Parents:** SUB-001
+- **Acceptance criterion:** {{OBJECTIVE_COMPONENT_CRITERION}}
+- **Verification:** UNITV-001 (analysis)
+- **Origin / risk:** {{ORIGIN_AND_RISK}}
+- **Context:** [{{CONTEXT_TOPIC_TITLE}}]({{CONTEXT_TOPIC_LINK}})

--- a/document-repository-v-model/assets/templates/v-model/index.md
+++ b/document-repository-v-model/assets/templates/v-model/index.md
@@ -1,0 +1,25 @@
+# {{PRODUCT_NAME}} V-Model
+
+- **Profile status:** draft
+- **Product boundary:** {{PRODUCT_BOUNDARY}}
+- **Acceptance authority:** {{ACCEPTANCE_AUTHORITY}}
+- **Last reviewed:** {{REVIEW_DATE}}
+
+This profile is a repository-specific specification and evidence map. It is not a claim
+of compliance with NASA, FDA, ECSS, or V-Modell XT.
+
+## Left-side specification
+
+1. [Stakeholder outcomes](01-stakeholder-outcomes.md)
+2. [System requirements](02-system-requirements.md)
+3. [Subsystem and interface contracts](03-subsystem-contracts.md)
+4. [Component contracts](04-component-contracts.md)
+
+## Right-side evidence
+
+- [Verification and acceptance actions](verification.md)
+
+## Baseline notes
+
+- {{BASELINE_NOTE}}
+- Unresolved intent remains explicit and does not form part of a baseline.

--- a/document-repository-v-model/assets/templates/v-model/verification.md
+++ b/document-repository-v-model/assets/templates/v-model/verification.md
@@ -1,0 +1,48 @@
+# Verification and Acceptance Actions
+
+Update status and durable evidence after execution. Set `passing` only when linked
+evidence exercises every clause in the pass criterion. Do not paste transient run logs.
+
+## ACC-001 — {{ACCEPTANCE_ACTION_TITLE}}
+
+- **Covers:** STK-001
+- **Method:** demonstration
+- **Procedure:** {{ACCEPTANCE_PROCEDURE}}
+- **Environment / configuration:** {{OPERATIONAL_ENVIRONMENT}}
+- **Pass criterion:** {{ACCEPTANCE_PASS_CRITERION}}
+- **Status:** planned
+- **Evidence:** None
+- **Nonconformance:** None
+
+## SYSV-001 — {{SYSTEM_VERIFICATION_TITLE}}
+
+- **Covers:** SYS-001
+- **Method:** test
+- **Procedure:** {{SYSTEM_TEST_PROCEDURE}}
+- **Environment / configuration:** {{SYSTEM_TEST_ENVIRONMENT}}
+- **Pass criterion:** {{SYSTEM_PASS_CRITERION}}
+- **Status:** planned
+- **Evidence:** None
+- **Nonconformance:** None
+
+## INTV-001 — {{INTEGRATION_VERIFICATION_TITLE}}
+
+- **Covers:** SUB-001
+- **Method:** test
+- **Procedure:** {{INTEGRATION_TEST_PROCEDURE}}
+- **Environment / configuration:** {{INTEGRATION_TEST_ENVIRONMENT}}
+- **Pass criterion:** {{INTEGRATION_PASS_CRITERION}}
+- **Status:** planned
+- **Evidence:** None
+- **Nonconformance:** None
+
+## UNITV-001 — {{COMPONENT_VERIFICATION_TITLE}}
+
+- **Covers:** CMP-001
+- **Method:** analysis
+- **Procedure:** {{COMPONENT_ANALYSIS_PROCEDURE}}
+- **Environment / configuration:** {{COMPONENT_ANALYSIS_ENVIRONMENT}}
+- **Pass criterion:** {{COMPONENT_PASS_CRITERION}}
+- **Status:** planned
+- **Evidence:** None
+- **Nonconformance:** None

--- a/document-repository-v-model/references/agent-context-documentation.md
+++ b/document-repository-v-model/references/agent-context-documentation.md
@@ -1,0 +1,100 @@
+# Agent Context Documentation
+
+Read this reference only when creating, migrating, splitting, reviewing, or compacting
+`.agents/context/`. Adapt the four needs from [Diátaxis](https://diataxis.fr/) for agent retrieval; do not turn them into four mandatory directories.
+This profile calls them **Guided learning**, **Task playbook**, **Reference**, and **Explanation**.
+
+## Choose one retrieval need
+
+| Need | Diátaxis form | The agent needs to | Include | Exclude |
+| --- | --- | --- | --- | --- |
+| Guided learning | [Tutorial](https://diataxis.fr/tutorials/) | Acquire an unfamiliar repository skill through a safe experience | One supported path, checkpoints, and expected observations | Production mutation, broad alternatives, and background essays |
+| Task playbook | [How-to guide](https://diataxis.fr/how-to-guides/) | Complete a concrete repository task while already competent | Preconditions, goal-directed actions, branches, validation, and recovery | Teaching detours and embedded rationale |
+| Reference | [Reference](https://diataxis.fr/reference/) | Look up exact facts about current machinery | Terse commands, mappings, interfaces, errors, limits, and source anchors | Workflow instruction and argumentative prose |
+| Explanation | [Explanation](https://diataxis.fr/explanation/) | Understand why the implementation has its present shape | Mental models, rationale, alternatives, tradeoffs, and consequences | Step-by-step procedures and duplicated lookup tables |
+
+Use the [Diátaxis compass](https://diataxis.fr/compass/): ask whether the agent is acting or understanding, then whether it is acquiring or applying knowledge. Guided learning is action plus acquisition; a Task playbook is action plus application.
+Reference is cognition plus application, and Explanation is cognition plus acquisition.
+
+Give each leaf one dominant need. Split only when a substantial section has a different open condition and would be useful independently. Link incidental facts or rationale instead of duplicating them.
+
+## Route for selective loading
+
+Use `.agents/index.md` as the entry point and keep specification routing visually
+separate from working context:
+
+```markdown
+## Specification
+
+- [V-model](v-model/index.md) — open when changing observable behavior or evidence.
+
+## Working context
+
+| Context | Need | Open when | Do not open when |
+| --- | --- | --- | --- |
+| [Release flow](context/releases.md) | Task playbook | Preparing or recovering a release | Editing local algorithms |
+```
+
+Keep context leaves topic-oriented and flat by default. Do not create empty category
+directories. Following [complex-hierarchy guidance](https://diataxis.fr/complex-hierarchies/), add one subindex for a coherent product, domain, or workflow boundary when an index presents more than seven context choices or exceeds its router budget.
+Permit at most one context-subindex hop from `.agents/index.md` to a leaf; a leaf-to-leaf
+link does not make the destination routed. Apply the seven-choice budget to every index;
+split an oversized domain into sibling subindexes rather than nesting another level.
+
+A nested `AGENTS.md` should link directly to the relevant leaf when known rather than
+forcing the agent through an index. Add `Scope` only when products or audiences differ;
+preserve physical paths during classification and carry the four-part structure in `Need`.
+
+## Write a context leaf
+
+Start every leaf with this retrieval metadata:
+
+```markdown
+# Topic
+
+- **Context need:** Guided learning
+- **Open when:** ...
+- **Do not open when:** ...
+- **Related specification IDs:** SYS-001, SUB-002
+- **Review when:** ...
+```
+
+Use `None — repository-only workflow` only when the topic genuinely has no product-specification relationship. Add anchors and unresolved questions when they help the agent verify freshness or act safely.
+
+Shape the body for its need:
+
+- **Guided learning:** State the learning outcome and safe prerequisites. Lead through
+  one reproducible path with small checkpoints and expected observations. End with a
+  completion check and next capability. Link optional alternatives or theory elsewhere.
+- **Task playbook:** State the concrete objective, prerequisites, and constraints. Give
+  actions in goal order, branch where repository state requires it, then cover
+  validation, failure handling, rollback, or handoff. Assume baseline competence.
+- **Reference:** Optimize for scanning with concise tables, lists, and exact current
+  values. Follow the structure of the implementation being described and cite canonical
+  source anchors. Describe facts; do not prescribe a task or argue for a design.
+- **Explanation:** Begin with the question or mental model. Explain forces, rationale,
+  alternatives, tradeoffs, history that still affects current work, and implications.
+  Keep the topic bounded and link operational steps or exact facts elsewhere.
+
+## Preserve the specification boundary
+
+`.agents/v-model/` is the only normative product-specification tree. It must remain
+understandable without context documents. A context Reference describes current
+implementation facts; it does not define required product behavior.
+
+When an implementation decision becomes externally observable, promote only the invariant
+and its objective acceptance meaning into the V-model. Keep the chosen mechanism and
+rationale in context, with links back to the affected specification IDs. If intent is
+unresolved, record the uncertainty instead of promoting observed behavior.
+
+## Migrate and review proportionally
+
+For new material, create a leaf only for a recurring retrieval need supported by actual
+repository work. During migration, inventory mixed prose, assign a dominant need, retain
+useful anchors, and update inbound links atomically. Do not move or split content merely
+to populate all four needs.
+
+During review, verify that open conditions are distinct, every leaf is routed, body
+shape matches its declared need, and links replace duplicated prose. Merge or split only
+for retrieval, remove stale current state, and keep generated output and run logs outside
+the live context tree.

--- a/document-repository-v-model/references/discovery-and-interviews.md
+++ b/document-repository-v-model/references/discovery-and-interviews.md
@@ -1,0 +1,159 @@
+# Discovery and Interviews
+
+Use this reference to establish intended behavior for a new project or recover it from
+an existing repository. Keep interviews short and evidence-led.
+
+## Contents
+
+- [New projects](#new-projects)
+- [Existing projects](#existing-projects)
+- [Confidence and baseline rules](#confidence-and-baseline-rules)
+
+## New projects
+
+Interview and draft in rounds. After each round, summarize the proposed records,
+uncertainties, and exclusions for developer confirmation.
+
+### Round 1: repository and intent
+
+Ask only enough to establish:
+
+- Repository and independently released product boundaries.
+- Stakeholders, actors, and who accepts the result.
+- Operational scenarios and intended environments.
+- Outcomes and measurable success.
+- Explicit non-goals and prohibited behavior.
+- Consequence of failure, risk, and required reviewer independence.
+- Legal, platform, compatibility, resource, or delivery constraints.
+
+Draft `STK` outcomes without implementation terminology. Obtain explicit confirmation
+before treating them as the baseline.
+
+### Round 2: observable system behavior
+
+Ask about capabilities, inputs and outputs, external interfaces, quality attributes,
+error behavior, compatibility ranges, performance budgets, and recovery behavior. Draft
+`SYS` records and `SYSV` intent together. Resolve vague adjectives with examples or
+thresholds.
+
+### Round 3: logical contracts
+
+Derive `SUB` responsibilities and boundary semantics, then only the non-obvious `CMP`
+contracts needed for correct implementation and evidence. Ask the developer when a
+choice changes observable behavior or represents a genuine tradeoff. Do not ask them to
+invent details that repository conventions can settle safely.
+
+### Round 4: implementation context and evidence
+
+Separate normative specification and router-local rules before capturing architecture,
+packages, tools, workflows, and rationale in `.agents/context/`. Assign each retained
+context leaf exactly one dominant need: `Guided learning`, `Task playbook`, `Reference`,
+or `Explanation`. Create only leaves that answer an evidenced agent retrieval need.
+Map all right-side actions, unresolved issues, environments, and durable evidence
+locations. Add source routers only after actual code roots or meaningful boundaries
+exist.
+
+Finish by showing the intended specification, unresolved decisions, and planned evidence
+to the developer for approval.
+
+## Existing projects
+
+Start with read-only discovery. Parallelize only when applicable instructions permit it.
+Use distinct lanes so conclusions can be reconciled:
+
+1. Public docs, examples, manifests, release metadata, and declared compatibility.
+2. Source entry points, architecture, state and error boundaries, and external APIs.
+3. Tests, fixtures, CI, supported environments, runtime checks, and observed behavior.
+4. Existing `AGENTS.md`, `.agents/`, design documents, issue references, and relevant
+   history.
+
+Do not change source code during a documentation-only discovery or forward test.
+Do not execute a credentialed, destructive, externally mutating, costly, or
+production-facing test merely to establish documentation evidence. Unless the developer
+has explicitly authorized a suitably isolated and reversible run, record the action as
+planned and specify the fixture, safeguards, and acceptance environment it needs.
+
+### Maintain an evidence ledger
+
+For each candidate claim, record:
+
+| Field | Meaning |
+| --- | --- |
+| Candidate claim | The smallest behavior, intent, decision, or conflict being assessed |
+| Evidence | Exact file, symbol, test, commit, release, or developer statement |
+| Evidence kind | Documentation, code, test, runtime, history, or interview |
+| Confidence | High, medium, or low, with a short reason |
+| Conflict | Contrary evidence or missing perspective |
+| Proposed class | Intended specification, accepted decision, defect/spec gap, obsolete behavior, or unresolved |
+
+Code and tests are evidence of current behavior. They are not automatic proof that the
+behavior is desired. Public documentation may describe intent but still be stale. A
+developer statement can establish intent, but compare it with shipped compatibility and
+stakeholder commitments before removing behavior.
+Do not equate an export list with a stable public contract: reconcile exports, explicit
+stability/private markers, release notes, supported examples, and actual downstream use.
+
+For CI evidence, trace each matrix value, environment variable, feature flag, tag, and
+filter through the test entry point to the selected cases. Similar job and selector
+names are not evidence that the intended shard actually runs.
+
+Before turning a candidate into a normative statement, try to falsify it. Probe empty,
+malformed, boundary, fallback, negative, and repeated-call cases in proportion to risk.
+Exercise each public entry point, default, override, and diagnostic path that can reach
+the behavior.
+Treat words such as “all,” “every,” “any,” “deterministic,” and “supported” as prompts
+for counterexamples. If known behavior contradicts a proposed universal claim, keep the
+conflict unresolved or narrow the record; draft status does not make an internally
+inconsistent statement acceptable.
+
+For filesystem deletion or other destructive state changes, also probe canonicalized
+and traversal paths, symlinks or aliases, pre-existing and stale success markers,
+partial prior runs, zero/negative/nonnumeric/overflow limits, and repeated invocations.
+State containment relative to resolved targets, not merely a configured path string.
+Treat “fail open,” “continue,” and “recover” as caller-control-flow claims unless
+evidence separately establishes remote atomicity, rollback, idempotent retry, and the
+resulting partial state.
+
+### Interview only the gaps
+
+After discovery, ask compact questions about matters inspection cannot establish:
+
+- Which users and scenarios are authoritative?
+- Is a surprising behavior intentional, tolerated debt, or a defect?
+- Which compatibility promises and exclusions must remain?
+- Which conflicts should be resolved now and which remain explicit?
+- What failure consequences or acceptance thresholds drive assurance?
+
+Show the exact competing evidence with each question. Avoid asking for facts already
+available in the repository.
+
+### Classify before moving prose
+
+Assign each observed claim to one class:
+
+- **Intended specification:** confirmed normative behavior; move or write it in the
+  V-model with objective evidence.
+- **Accepted implementation decision:** current “how” and rationale; keep it in a context
+  topic linked to the fulfilled specification.
+- **Defect or specification gap:** code and intended behavior differ; keep the mismatch
+  explicit and do not rewrite either side to hide it.
+- **Obsolete behavior:** no longer intended; remove current-state guidance and retain a
+  short retirement note only when compatibility requires one.
+- **Unresolved:** evidence conflicts or intent is unavailable; record the question,
+  evidence, owner, and review trigger.
+
+Preserve useful existing open/avoid criteria, source anchors, test anchors, commands, and
+local rules. Replace duplicated normative prose with canonical V-model links. After
+separating specification and router-local material, classify each retained context leaf
+as `Guided learning`, `Task playbook`, `Reference`, or `Explanation`; do not create
+empty category scaffolding.
+
+## Confidence and baseline rules
+
+- Baseline only developer-confirmed or otherwise authoritative intended behavior.
+- Leave inferred records in `draft` status and identify their evidence.
+- Do not turn “the test currently passes” into a stakeholder outcome.
+- Do not infer that a cited test covers clauses or edge cases it never exercises.
+- Do not turn one example into a general compatibility guarantee.
+- Do not silently choose between documentation and code when they conflict.
+- Record what was not inspected and why.

--- a/document-repository-v-model/references/repository-layout.md
+++ b/document-repository-v-model/references/repository-layout.md
@@ -1,0 +1,144 @@
+# Repository Layout
+
+Use this reference when creating or migrating the documentation tree, declaring code
+roots, or deciding where nested routers and topic files belong.
+
+## Contents
+
+- [Why this layout](#why-this-layout)
+- [Default topology](#default-topology)
+- [Declare code roots](#declare-code-roots)
+- [Keep routers small](#keep-routers-small)
+- [Route repository context](#route-repository-context)
+- [Keep specification separate](#keep-specification-separate)
+- [Use the templates selectively](#use-the-templates-selectively)
+- [Exclude transient material](#exclude-transient-material)
+
+## Why this layout
+
+[OpenAI’s harness-engineering guidance](https://openai.com/index/harness-engineering/)
+describes a short `AGENTS.md` as a map into structured repository knowledge, with
+progressive disclosure and mechanical checks for cross-links and drift. Apply that
+pattern here with `.agents/` as the selectively loaded knowledge tree. The exact
+directory name is this profile’s convention, not an OpenAI product requirement.
+
+## Default topology
+
+```text
+AGENTS.md
+<code-root>/AGENTS.md
+<meaningful-subsystem>/AGENTS.md
+.agents/
+├── index.md
+├── context/
+│   └── <topic>.md
+└── v-model/
+    ├── index.md
+    ├── 01-stakeholder-outcomes.md
+    ├── 02-system-requirements.md
+    ├── 03-subsystem-contracts.md
+    ├── 04-component-contracts.md
+    └── verification.md
+```
+
+Treat this as a default, not a demand for empty files. Create the complete V-model
+profile, but add context topics and nested routers only for information and boundaries
+that exist.
+
+## Declare code roots
+
+- Require `src/AGENTS.md` whenever `src/` exists.
+- For a nonstandard or polyglot repository, list every actual code root in the root
+  router and create an equivalent router in each one. Examples include `app/`, `gui/`,
+  `packages/`, `cmd/`, or a repository root that contains executable code directly.
+- Pass the same roots to the linter with repeated `--source-root` options. Do not invent
+  a `src/` directory just to satisfy the profile.
+- Treat an independently built frontend, backend, library, plugin, or service as a
+  likely code root when its manifest and workflow are distinct.
+
+## Keep routers small
+
+Every `AGENTS.md` contains only:
+
+1. Its scope and inherited-scope deltas.
+2. Commands that are valid in that scope.
+3. Local rules or invariants that directly guide work.
+4. Links to canonical topic or specification documents, with an explicit “open when”
+   condition.
+
+Do not restate architecture, requirement records, rationale, history, or long testing
+guides. Do not ask an agent to read `.agents/` recursively. A nested router overrides or
+adds to inherited guidance; it does not copy the parent.
+
+Add a nested router only when a directory is a meaningful subsystem, module, ownership
+boundary, or distinct development workflow. File count alone is not a boundary. A stable
+interface, separate release unit, different toolchain, or different validation command
+is stronger evidence.
+
+## Route repository context
+
+Make `.agents/index.md` the repository-wide router. Link directly to context leaves when
+the relevant leaf is known, and give every link explicit “open when” and “do not open
+when” conditions. Keep names aligned to an agent's retrieval task rather than
+organizational history.
+
+When creating, classifying, splitting, or reviewing context, read
+[agent context documentation](agent-context-documentation.md). It defines four
+agent-facing retrieval needs and the adaptive rules for adding subindexes without
+forcing four category directories. Keep the tree flat until a real product, domain, or
+workflow boundary makes another routing hop useful. Never ask an agent to preload a
+category or recursively read `.agents/context/`.
+
+## Keep specification separate
+
+`.agents/v-model/` is the only normative product-specification tree in this profile.
+Keep it understandable without opening `.agents/context/`. Section-level context links
+may supply essential background, but must not carry normative meaning.
+
+For a large layer, replace its canonical Markdown file with a same-named directory:
+
+```text
+.agents/v-model/03-subsystem-contracts/
+├── index.md
+├── storage.md
+└── transport.md
+```
+
+The directory index routes to shards. Keep record IDs unique repository-wide. Apply the
+same file-or-directory form to `verification` when verification records need sharding.
+
+For independently released products in one repository, make `.agents/v-model/index.md`
+route to one complete profile per product:
+
+```text
+.agents/v-model/
+├── index.md
+├── product-a/
+│   ├── index.md
+│   └── <all four layers plus verification>
+└── product-b/
+    ├── index.md
+    └── <all four layers plus verification>
+```
+
+Do not combine products merely because they share a repository. Do not split one product
+merely because it uses several languages.
+
+## Use the templates selectively
+
+- `assets/templates/AGENTS-root.md`: root router.
+- `assets/templates/AGENTS-source.md`: code-root or meaningful-boundary router.
+- `assets/templates/context-topic.md`: one context leaf, shaped for its retrieval need.
+- `assets/templates/v-model/`: a complete small single-product profile.
+
+Copy, rename, and fill only what the repository needs. Replace all `{{TOKEN}}` values.
+Preserve existing useful prose by moving it to the correct canonical home and replacing
+the old copy with a link.
+
+## Exclude transient material
+
+Keep generated reports, large CSV/JSON exports, images, database files, recordings, and
+run logs outside the live `.agents/` tree. Link to a durable evidence location instead.
+Retain current status and durable references in `verification.md`, not copied console
+output. Rely on Git history for obsolete prose unless a short retirement record is
+needed for compatibility.

--- a/document-repository-v-model/references/review-and-compaction.md
+++ b/document-repository-v-model/references/review-and-compaction.md
@@ -1,0 +1,136 @@
+# Review and Compaction
+
+Use this reference for scheduled audits, release readiness, drift checks, and efforts to
+reduce agent context cost without weakening meaning.
+
+## Contents
+
+- [Review triggers](#review-triggers)
+- [Independent review streams](#independent-review-streams)
+- [Reconciliation order](#reconciliation-order)
+- [Compaction rules](#compaction-rules)
+- [Warning budgets](#warning-budgets)
+- [Semantic consistency checklist](#semantic-consistency-checklist)
+- [Idempotence check](#idempotence-check)
+
+## Review triggers
+
+Review after changes to observable behavior, public interfaces, architecture, code roots,
+ownership boundaries, supported environments, or test strategy. Also review before a
+major release and at least quarterly for an actively maintained repository.
+
+Run the linter first to expose mechanical failures, but do not treat a clean linter result
+as semantic approval.
+
+## Independent review streams
+
+When scale and permissions allow, separate these passes:
+
+1. **Router and link integrity:** scopes, code roots, inheritance deltas, open/avoid
+   routing, local links, and meaningful boundaries.
+2. **V-model and traceability:** record quality, parent layers, objective criteria,
+   right-side coverage, methods, statuses, evidence, and nonconformance.
+3. **Code/test versus context:** current implementation, tests, CI, commands, anchors,
+   compatibility, decision-document drift, and context-need fit.
+4. **Duplication and context cost:** repeated prose, oversized routers, overlapping
+   or mixed-purpose topics, stale logs, unnecessary routing hops, and material that
+   should not load by default.
+
+Use an independent reviewer for high-risk conclusions. Reconcile findings centrally;
+reviewers identify evidence and impact but do not each rewrite the canonical files.
+
+## Reconciliation order
+
+1. Resolve or explicitly record conflicts about intent.
+2. Update canonical V-model or context content.
+3. Repair traceability and durable evidence references.
+4. Update indexes and detailed topic routing.
+5. Shorten root and nested routers last.
+6. Re-run mechanical and semantic review after every move or deletion.
+
+This order prevents a concise router from pointing to stale or missing detail.
+
+## Compaction rules
+
+- Replace duplicated prose with one canonical statement and contextual links.
+- Keep a rule in the closest router where it applies; remove inherited restatements.
+- Separate normative specification and router-local rules before classifying context.
+- Assign every context leaf exactly one dominant need: `Guided learning`,
+  `Task playbook`, `Reference`, or `Explanation`.
+- Split a mixed-purpose context document only when substantial sections serve distinct
+  retrieval needs; otherwise keep its dominant need and link to supporting context.
+- Do not add empty need categories, and do not move a leaf merely to fill a taxonomy.
+- Merge small topics only when agents always need them together and they share a
+  dominant need.
+- Remove obsolete current-state material and rely on Git history.
+- Retain a brief retirement/replacement record only when compatibility or migration
+  work needs it.
+- Never shorten a requirement by weakening actors, conditions, thresholds, exclusions,
+  or pass/fail meaning.
+- Prune historical run logs from verification records. Retain current status, durable
+  evidence locations, and unresolved nonconformance.
+- Keep generated reports and bulky artifacts outside `.agents/`.
+
+Before deleting or moving a document, find all inbound links and specification IDs.
+Repair those references in the same change. Verify that a proposed merge does not combine
+normative specification with implementation rationale.
+
+## Warning budgets
+
+The linter warns, rather than fails, at these default budgets:
+
+| Document | Lines | Words | Records |
+| --- | ---: | ---: | ---: |
+| Root `AGENTS.md` | 100 | 700 | — |
+| Nested `AGENTS.md` | 40 | 250 | — |
+| Any `.agents/**/index.md` | 100 | 600 | — |
+| Context detail or V-model shard | 200 | 1,200 | 40 |
+
+Treat a warning as a retrieval-cost signal. A justified large shard may remain, but an
+oversized router is usually the wrong place for detail. Use `--fail-on-warn` for a strict
+release gate after known proportional exceptions have been resolved.
+
+The linter also warns about invalid context metadata, unreachable context leaves,
+oversized or over-nested context routing, unjustified missing specification links,
+duplicated prose, bulky artifacts, likely source boundaries without routers, and
+placeholders in baselined profiles.
+
+## Semantic consistency checklist
+
+- Does each `AGENTS.md` say what to open and when, without preloading everything?
+- Starting from a concrete task, can an agent reach the relevant context leaf without
+  browsing or loading unrelated context?
+- Does each context leaf consistently serve its declared dominant need:
+  `Guided learning`, `Task playbook`, `Reference`, or `Explanation`?
+- Do prose claims about child routers match routers that actually exist?
+- Are commands executable from the scope where they are documented?
+- Does each normative record express intended behavior rather than observed accidents?
+- Has each universal or deterministic claim survived boundary and counterexample review?
+- For destructive behavior, were path traversal, symlinks, stale state, partial prior
+  runs, invalid limits, and repeated invocations checked?
+- Do fail-open or recovery claims distinguish caller continuation from partial side
+  effects, rollback, and retry behavior?
+- Can the V-model be understood without decision documents?
+- Do parent and verification links represent real semantic coverage?
+- Does every claimed consumer of a shared schema or registry actually load or derive
+  from it, rather than maintain an independent copy?
+- Does each criterion permit an objective decision, and does cited evidence exercise
+  every clause, direction, entry point, and edge case it claims?
+- Are fixtures discriminating, or could a swapped field, direction, branch, or order
+  produce the same expected result?
+- Do CI matrix values, environment variables, tags, and filters actually select the
+  cited tests end to end?
+- Does each `passing` status still match durable evidence?
+- Are current source paths, workflow names, and tool choices kept out of normative
+  compatibility or interface outcomes?
+- Are failure paths, external interfaces, performance, security, and compatibility
+  covered in proportion to risk?
+- Do context decisions still match source and test anchors?
+- Are unresolved mismatches visible rather than normalized away?
+
+## Idempotence check
+
+After a migration or broad update, run a second documentation pass from the resulting
+repository state. It should make no unnecessary edits. A nonempty second diff indicates
+unstable ordering, duplicated authority, unresolved template tokens, or unclear routing.
+Fix the cause instead of accepting churn.

--- a/document-repository-v-model/references/subagent-playbooks.md
+++ b/document-repository-v-model/references/subagent-playbooks.md
@@ -1,0 +1,131 @@
+# Subagent Playbooks
+
+Use this reference only when the environment and applicable instructions permit
+delegation. Scale independence and specialist effort to risk; keep one coordinator
+responsible for intent, reconciliation, and final edits.
+
+## Contents
+
+- [Isolation rules](#isolation-rules)
+- [Risk-scaled staffing](#risk-scaled-staffing)
+- [Standard V-layer cohorts](#standard-v-layer-cohorts)
+- [Existing-repository discovery](#existing-repository-discovery)
+- [Consistency review](#consistency-review)
+- [Clean-room forward testing](#clean-room-forward-testing)
+
+## Isolation rules
+
+- Give each operator a concrete, bounded, primarily read-only lane.
+- Provide the skill path, repository path, exact pinned commit, and a normal user-style
+  request. Do not reveal expected answers, suspected defects, or another reviewer’s
+  conclusions.
+- Use a separate disposable clone or worktree per writing agent. Never let agents edit
+  the same worktree.
+- For discovery and evaluation, prohibit source-code changes and pushes.
+- Ask for evidence with exact file/symbol/test anchors, confidence, conflicts, and
+  unresolved questions.
+- Keep one slot for the coordinator when concurrency is limited.
+
+If subagents are unavailable, perform the same lanes sequentially and use a fresh context
+for the independent review when possible.
+
+## Risk-scaled staffing
+
+| Risk/scale | Suggested approach |
+| --- | --- |
+| Tiny, low-risk repository | One operator plus a short independent trace/size review |
+| Ordinary repository | Coordinator plus documentation/source and test/trace operators |
+| Large brownfield or polyglot repository | Coordinator plus code/spec archaeologist, verification mapper, and boundary/router reviewer |
+| High assurance or destructive behavior | Add domain, security/safety, failure-injection, environment, and independent trace specialists as relevant |
+
+Do not add specialists merely to fill slots. Add them when a distinct evidence domain or
+independence requirement exists.
+
+## Standard V-layer cohorts
+
+| Layer | Cohort |
+| --- | --- |
+| `STK` / `ACC` | Domain or stakeholder proxy; acceptance-scenario designer; independent trace reviewer |
+| `SYS` / `SYSV` | Requirements analyst; black-box verification designer/executor; relevant performance, security, or compatibility specialist; reviewer |
+| `SUB` / `INTV` | One contract investigator per important boundary; dependency/environment or failure-injection specialist; architecture/trace integrator |
+| `CMP` / `UNITV` | Component/unit-test investigator; static-analysis or code-inspection investigator; orphan/coverage reviewer |
+
+A specialist may cover several roles in a small repository. Preserve independence for the
+final trace review when failure impact warrants it.
+
+## Existing-repository discovery
+
+Give operators nonoverlapping questions:
+
+- **Public contract operator:** Inspect public docs, examples, manifests, release metadata,
+  and declared compatibility. Return candidate observable claims and contradictions.
+- **Code archaeologist:** Inspect entry points, data/state/error boundaries, public APIs,
+  and major subsystems. Return observed behavior and architecture decisions separately.
+- **Verification mapper:** Inspect tests, CI, fixtures, supported environments, skips,
+  expected failures, and evidence durability. Return coverage and orphan candidates.
+- **Agent-context reviewer:** Inspect existing routers and context for scope, duplication,
+  open/avoid criteria, anchors, staleness, and likely migration targets. Separate
+  specification and router-local rules, then classify each retained leaf as
+  `Guided learning`, `Task playbook`, `Reference`, or `Explanation`.
+
+The coordinator merges evidence into one ledger, asks the developer only unresolved
+intent questions, and classifies claims before anyone writes a baseline.
+
+## Consistency review
+
+Assign independent passes for router/link integrity, V-model/traceability, source/test
+drift, and duplication/token cost. Require each finding to include:
+
+1. Severity and affected IDs/files.
+2. Exact evidence.
+3. Why it is inconsistent or costly.
+4. Smallest safe correction.
+5. Whether developer intent is required.
+
+For every `passing` action sampled, open the cited evidence and compare its exercised
+cases with each phrase in the procedure and pass criterion. Sample universal normative
+claims with at least one boundary or counterexample search. Mechanical reverse links are
+not semantic coverage.
+
+For the context-cost pass, start with representative repository tasks and follow only
+the links an agent would be told to open. Report missing routes, unnecessary hops,
+indexes presenting more than seven choices, unrelated documents loaded, and mixed or
+incorrect context needs. Do not recursively preload `.agents/` to perform this review.
+
+Have the coordinator deduplicate findings and apply changes in the reconciliation order
+from `review-and-compaction.md`.
+
+## Clean-room forward testing
+
+Skill maintainers should forward-test with disposable clones pinned to exact commits.
+Use three small operators concurrently with one coordinator; for a large case use an
+operator, code/spec archaeologist, and verification mapper, then reuse them as independent
+cross-reviewers.
+
+Core release cases:
+
+- `QuantumSavory.jl`: preserve selective router/context strengths while detecting drift
+  and separating specification from decisions.
+- `PBCCompiler.jl`: migrate a monolithic `AGENTS.md`.
+- `TermInterface.jl`: verify proportional output for a tiny library.
+- `QuantumClifford.jl`: exercise brownfield discovery and subsystem traceability.
+- `WebQuantumSavory`: exercise polyglot roots and cross-stack contracts.
+
+Rotate `QuantumInterface.jl` for externally consumed contracts,
+`julia-buildkite-plugin` for no conventional `src/`, and `AnythingLLMDocs.jl` for
+external-service and safety-aware acceptance planning. Never execute a live destructive
+test merely to evaluate documentation generation.
+
+Require:
+
+- No hard linter errors or avoidable router warnings.
+- Complete bidirectional traceability.
+- No implementation decisions duplicated into specification.
+- No observed behavior promoted to intent without evidence or confirmation.
+- Selective context loading and no source-code changes.
+- An empty unnecessary second-pass diff.
+- Independent approval for correctness, proportionality, interview quality, and context
+  efficiency.
+
+Keep prompts, raw diffs, linter JSON, and scores outside the shipped skill. Retain them
+only until findings are incorporated, then remove clones and temporary artifacts.

--- a/document-repository-v-model/references/v-model-and-traceability.md
+++ b/document-repository-v-model/references/v-model-and-traceability.md
@@ -1,0 +1,183 @@
+# V-Model and Traceability
+
+Use this reference whenever writing, changing, or reviewing normative specification and
+verification records.
+
+## Contents
+
+- [Profile and source basis](#profile-and-source-basis)
+- [Incremental V-model](#incremental-v-model)
+- [Four specification layers](#four-specification-layers)
+- [Specification record format](#specification-record-format)
+- [Verification action format](#verification-action-format)
+- [Traceability rules](#traceability-rules)
+- [Specification versus decisions](#specification-versus-decisions)
+- [Risk tailoring](#risk-tailoring)
+
+## Profile and source basis
+
+This is a repository-neutral V-profile. It borrows useful distinctions and traceability
+practices; it does not establish compliance with NASA, FDA, ECSS, V-Modell XT, or any
+regulated lifecycle.
+
+- [NASA Systems Engineering Handbook §2.4](https://www.nasa.gov/reference/2-4-distinctions-between-product-verification-and-product-validation/)
+  distinguishes verification of compliance with requirements from validation of the
+  intended purpose in the intended environment. Preserve that distinction: `ACC`
+  actions validate stakeholder outcomes; the other right-side records verify specified
+  behavior or contracts.
+- [FDA General Principles of Software Validation](https://www.fda.gov/media/73141/download)
+  maps unit evidence to detailed design, integration evidence to high-level design, and
+  system evidence to software requirements; it also calls for objective pass/fail
+  records and traceability in both directions. Use the mapping without implying that
+  ordinary repositories are medical-device submissions.
+- [ECSS-E-ST-40C Rev.1](https://ecss.nl/standard/ecss-e-st-40c-rev-1-software-30-april-2025/)
+  emphasizes tailoring, early verification/validation planning, requirements-to-design
+  traceability, controlled evidence, and risk-scaled independence. Use only these
+  selected practices.
+
+## Incremental V-model
+
+Do not run the profile as a single-pass waterfall. For each feature, defect correction,
+compatibility change, or release:
+
+1. Identify affected stakeholder outcomes and system requirements.
+2. Update logical contracts without encoding chosen file/package topology.
+3. Plan or revise right-side actions while writing the left-side records.
+4. Implement at the bottom of the V.
+5. Execute unit/inspection, integration, system, and acceptance evidence as applicable.
+6. Update current status, durable evidence, nonconformance, and regression impact.
+
+Baseline records incrementally after developer confirmation. A change to a baselined
+product gets its own mini-V and regression analysis.
+
+## Four specification layers
+
+| Layer | Include | Exclude | Right side |
+| --- | --- | --- | --- |
+| `STK-###` stakeholder outcomes | Actors, operational scenarios, intended outcomes, success measures, explicit exclusions | Package names, file layout, algorithms | `ACC-###` operational validation and acceptance |
+| `SYS-###` system requirements | Observable capabilities, quality attributes, constraints, external boundaries, objective acceptance criteria | Internal architecture unless externally observable | `SYSV-###` black-box system verification |
+| `SUB-###` subsystem/interface contracts | Logical responsibilities, data/state/error semantics, boundary contracts | Chosen package and file topology | `INTV-###` integration, contract, and failure-path verification |
+| `CMP-###` component contracts | Non-obvious behavior, invariants, pre/postconditions, resource budgets needed to implement or verify | Exhaustive function documentation and obvious behavior | `UNITV-###` unit, property, static-analysis, or inspection evidence |
+
+Parent layers are strict: `STK` has no parent; `SYS` points to `STK`; `SUB` points to
+`SYS`; `CMP` points to `SUB`. Use multiple parents when one record refines several
+concerns. Keep IDs stable when wording changes; retire rather than reuse an ID.
+
+## Specification record format
+
+Use a level-two or deeper heading and the exact required fields:
+
+```markdown
+## SYS-014 — Export results without data loss
+
+- **Normative statement:** The product shall ...
+- **Parents:** STK-003
+- **Acceptance criterion:** Given ..., when ..., then ...
+- **Verification:** SYSV-008 (test), SYSV-011 (analysis)
+- **Origin / risk:** Customer interview; medium data-loss risk
+- **Context:** [Persistence decision](../context/persistence.md)
+```
+
+Required fields are `Normative statement`, `Parents`, `Acceptance criterion`, and
+`Verification`. `Origin / risk` and `Context` are optional. Put `None` in `Parents` only
+for `STK` records. Every verification mapping includes an action ID and one method in
+parentheses: `test`, `analysis`, `inspection`, or `demonstration`.
+
+Write one independently testable normative statement per record. Make the acceptance
+criterion objective enough for a future agent to decide pass or fail. Avoid vague terms
+such as “fast,” “robust,” or “user-friendly” unless a measurable threshold or scenario
+defines them.
+
+## Verification action format
+
+Store all right-side actions in `verification.md` or its shards:
+
+```markdown
+## SYSV-008 — Verify lossless result export
+
+- **Covers:** SYS-014
+- **Method:** test
+- **Procedure:** Run ...
+- **Environment / configuration:** Supported release build on ...
+- **Pass criterion:** The exported ...
+- **Status:** passing
+- **Evidence:** [`tests/export_roundtrip.py`](../../tests/export_roundtrip.py)
+- **Nonconformance:** None
+```
+
+Every action requires all eight fields. Use statuses consistently:
+
+| Status | Meaning |
+| --- | --- |
+| `planned` | The full action is designed but its durable test, analysis, inspection, or demonstration is not yet implemented. |
+| `implemented` | A durable action artifact exists, but current full-criterion execution evidence is absent or incomplete. |
+| `passing` | Current durable evidence demonstrates every pass-criterion clause in the named environment. |
+| `failing` | Current evidence violates at least one pass-criterion clause. |
+| `blocked` | Execution cannot proceed; name the blocker and owner or trigger. |
+| `waived` | Authorized rationale accepts the missing or failing evidence; link the approval. |
+
+A `passing` action must name durable evidence: a committed test or report, stable
+CI/release record, analysis file, or inspection record. Do not use pasted logs or a claim
+such as “tested manually” as the only evidence.
+For an `implemented` inspection action, cite a durable checklist, review record, or
+automated check; the source file being inspected is not itself the inspection artifact.
+
+Record a failing or blocked action honestly and link its nonconformance. A waiver needs
+an explicit rationale and approval anchor. One action may cover several specifications,
+and one specification may require several actions.
+
+Match the action’s procedure and pass criterion to the cited evidence clause by clause.
+If a specification contains several conditions, either exercise every condition or split
+the evidence into separate actions. Never mark an action `passing` because adjacent
+behavior is tested, because source inspection suggests it should work, or because only
+one direction or entry point is covered. Use a separate `analysis` or `inspection`
+action for source evidence and record unexercised cases as nonconformance or planned
+work.
+Choose fixtures that can distinguish the claimed outcomes. Symmetric or identical
+inputs cannot establish ordering, direction, field identity, or correct branch routing
+when a swapped implementation would produce the same result.
+
+## Traceability rules
+
+Maintain bidirectional many-to-many links:
+
+- Every specification lists at least one matching right-side action.
+- Every action lists at least one covered specification.
+- The action ID appears on both sides, and the method in the specification matches the
+  action’s `Method`.
+- `ACC` covers only `STK`; `SYSV` only `SYS`; `INTV` only `SUB`; `UNITV` only `CMP`.
+- Parent references point to existing records in the immediately higher layer.
+- Regular context documents link back to related specification IDs.
+- Plan verification while specifying the behavior; do not postpone all right-side
+  design until implementation is complete.
+
+Traceability demonstrates coverage, not truth. Review whether a test actually exercises
+the criterion and whether the criterion represents developer intent.
+
+## Specification versus decisions
+
+The V-model must stand alone as a behavioral contract. Keep these outside it:
+
+- Chosen language, framework, package, file, class, or database layout.
+- Current source-file locations and named CI jobs when the normative need is an API or
+  compatibility outcome.
+- Trade studies and rejected alternatives.
+- Build-tool choices and local development conventions.
+- Rationale that explains why one implementation was selected.
+
+Link to one relevant topic per subsystem section when background helps. If an
+implementation decision becomes an externally observable invariant, promote only that
+invariant into a `SYS`, `SUB`, or `CMP` statement. Leave the decision and rationale in
+`.agents/context/`. State a compatibility result independently of the workflow or tool
+currently used to demonstrate it.
+
+## Risk tailoring
+
+Record origin and risk when it changes assurance. Increase specialist review,
+environment fidelity, failure injection, evidence durability, and reviewer independence
+for safety, security, privacy, destructive operations, financial impact, hard real-time
+budgets, broad compatibility promises, or externally consumed interfaces.
+
+Keep low-risk tiny libraries proportional: a small number of precise records is better
+than one record per function. Tailoring may reduce ceremony, never the objective
+pass/fail meaning of a retained requirement.

--- a/document-repository-v-model/scripts/lint_repository_docs.py
+++ b/document-repository-v-model/scripts/lint_repository_docs.py
@@ -1,0 +1,1500 @@
+#!/usr/bin/env python3
+"""Lint agent-facing repository documentation without modifying the repository."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+SPEC_PREFIXES = ("STK", "SYS", "SUB", "CMP")
+ACTION_PREFIXES = ("ACC", "SYSV", "INTV", "UNITV")
+ALL_PREFIXES = SPEC_PREFIXES + ACTION_PREFIXES
+PREFIX_PATTERN = "|".join(sorted(ALL_PREFIXES, key=len, reverse=True))
+VALID_ID_RE = re.compile(rf"^(?:{PREFIX_PATTERN})-\d{{3}}$")
+VALID_ID_FIND_RE = re.compile(rf"\b(?:{PREFIX_PATTERN})-\d{{3}}\b")
+ID_CANDIDATE_RE = re.compile(
+    rf"(?<![A-Z0-9])(?:{PREFIX_PATTERN})(?:-[A-Za-z0-9_#?]+|[0-9#?][A-Za-z0-9_#?]*)"
+)
+HEADING_CANDIDATE_RE = re.compile(
+    rf"^(#{{1,6}})\s+((?:{PREFIX_PATTERN})"
+    r"(?:-[^\s—–:]+|[0-9#?][^\s—–:]*))(.*)$"
+)
+FIELD_RE = re.compile(r"^\s*[-*]\s+\*\*([^*]+):\*\*\s*(.*)$")
+LINK_RE = re.compile(r"!?\[[^\]\n]*\]\(\s*(<[^>\n]+>|[^)\n]+)\s*\)")
+REFERENCE_LINK_RE = re.compile(r"^\s*\[[^\]\n]+\]:\s*(<[^>\n]+>|\S+)")
+WORD_RE = re.compile(r"\b[\w'-]+\b", re.UNICODE)
+PLACEHOLDER_RE = re.compile(
+    r"\{\{[^{}\n]+\}\}|<[A-Z][A-Z0-9_ -]{2,}>|\b(?:TODO|TBD|FIXME|CHANGEME)\b"
+)
+
+LAYER_ENTRIES = {
+    "01-stakeholder-outcomes": "STK",
+    "02-system-requirements": "SYS",
+    "03-subsystem-contracts": "SUB",
+    "04-component-contracts": "CMP",
+    "verification": "ACTION",
+}
+EXPECTED_PARENT = {"STK": None, "SYS": "STK", "SUB": "SYS", "CMP": "SUB"}
+EXPECTED_ACTION = {"STK": "ACC", "SYS": "SYSV", "SUB": "INTV", "CMP": "UNITV"}
+EXPECTED_SPEC = {value: key for key, value in EXPECTED_ACTION.items()}
+METHODS = {"test", "analysis", "inspection", "demonstration"}
+STATUSES = {"planned", "implemented", "passing", "failing", "blocked", "waived"}
+
+SPEC_REQUIRED_FIELDS = {
+    "normative statement",
+    "parents",
+    "acceptance criterion",
+    "verification",
+}
+ACTION_REQUIRED_FIELDS = {
+    "covers",
+    "method",
+    "procedure",
+    "environment / configuration",
+    "pass criterion",
+    "status",
+    "evidence",
+    "nonconformance",
+}
+
+SKIPPED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "venv",
+    "__pycache__",
+    "node_modules",
+    "vendor",
+    "third_party",
+    "dist",
+    "build",
+    "coverage",
+}
+BOUNDARY_SKIPPED_DIRS = SKIPPED_DIRS | {
+    ".agents",
+    "docs",
+    "doc",
+    "test",
+    "tests",
+    "fixtures",
+    "examples",
+    "generated",
+    "artifacts",
+}
+CODE_SUFFIXES = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cs",
+    ".ex",
+    ".exs",
+    ".go",
+    ".h",
+    ".hpp",
+    ".java",
+    ".jl",
+    ".js",
+    ".jsx",
+    ".kt",
+    ".kts",
+    ".lua",
+    ".m",
+    ".mm",
+    ".php",
+    ".py",
+    ".rb",
+    ".rs",
+    ".scala",
+    ".sh",
+    ".swift",
+    ".ts",
+    ".tsx",
+    ".vue",
+}
+BOUNDARY_MARKERS = {
+    "CMakeLists.txt",
+    "Cargo.toml",
+    "Makefile",
+    "Package.swift",
+    "go.mod",
+    "build.gradle",
+    "build.gradle.kts",
+    "mix.exs",
+    "package.json",
+    "pom.xml",
+    "Project.toml",
+    "pyproject.toml",
+    "setup.cfg",
+    "setup.py",
+}
+ARTIFACT_SUFFIXES = {
+    ".bin",
+    ".csv",
+    ".db",
+    ".gif",
+    ".gz",
+    ".html",
+    ".jpeg",
+    ".jpg",
+    ".json",
+    ".jsonl",
+    ".log",
+    ".mp4",
+    ".pdf",
+    ".png",
+    ".sqlite",
+    ".svg",
+    ".tar",
+    ".tsv",
+    ".webm",
+    ".webp",
+    ".xml",
+    ".yaml",
+    ".yml",
+    ".zip",
+}
+NONE_VALUES = {"", "-", "—", "none", "n/a", "na", "not applicable"}
+CONTEXT_NEEDS = {
+    "guided learning": "Guided learning",
+    "task playbook": "Task playbook",
+    "reference": "Reference",
+    "explanation": "Explanation",
+}
+CONTEXT_METADATA_FIELDS = {
+    "context need",
+    "open when",
+    "do not open when",
+    "related specification ids",
+    "review when",
+}
+H2_RE = re.compile(r"^\s{0,3}##(?:[ \t]+|$)")
+JUSTIFIED_CONTEXT_WITHOUT_SPEC_RE = re.compile(
+    r"^none\s+—\s+\S(?:.*\S)?$", re.IGNORECASE
+)
+
+
+class InputError(Exception):
+    """Raised when repository input cannot be read safely."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    severity: str
+    code: str
+    path: str
+    line: int | None
+    message: str
+
+    def as_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "severity": self.severity,
+            "code": self.code,
+            "path": self.path,
+            "message": self.message,
+        }
+        if self.line is not None:
+            result["line"] = self.line
+        return result
+
+
+@dataclasses.dataclass
+class Record:
+    identifier: str
+    title: str
+    path: Path
+    line: int
+    fields: dict[str, str]
+    field_lines: dict[str, int]
+
+    @property
+    def prefix(self) -> str:
+        return self.identifier.split("-", 1)[0]
+
+
+@dataclasses.dataclass
+class Profile:
+    root: Path
+    files: set[Path]
+    status: str | None
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _normalize_field(name: str) -> str:
+    return re.sub(r"\s+", " ", name.strip().lower())
+
+
+def _clean_scalar(value: str) -> str:
+    return value.strip().strip("`*_").strip().lower()
+
+
+def _is_none(value: str) -> bool:
+    return _clean_scalar(value) in NONE_VALUES
+
+
+def _visible_lines(text: str) -> list[str]:
+    result: list[str] = []
+    fence: str | None = None
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        marker = stripped[:3]
+        if fence is None and marker in {"```", "~~~"}:
+            fence = marker
+            result.append("")
+        elif fence is not None:
+            result.append("")
+            if stripped.startswith(fence):
+                fence = None
+        else:
+            result.append(line)
+    return result
+
+
+def _normalized_paragraph(block: Sequence[tuple[int, str]]) -> str | None:
+    if any(line.lstrip().startswith(("#", "|", "<!--")) for _, line in block):
+        return None
+    joined = " ".join(line.strip() for _, line in block)
+    joined = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", joined)
+    joined = re.sub(r"^[\s>*+-]+", "", joined)
+    normalized = re.sub(r"[^\w]+", " ", joined.lower()).strip()
+    return normalized if len(WORD_RE.findall(normalized)) >= 40 else None
+
+
+class RepositoryDocsLinter:
+    def __init__(self, repository: Path, source_roots: Sequence[Path]) -> None:
+        self.repository = repository.resolve()
+        self.source_roots = [path.resolve() for path in source_roots]
+        self.errors: list[Finding] = []
+        self.warnings: list[Finding] = []
+        self._finding_keys: set[tuple[str, str, str, int | None, str]] = set()
+        self._text_cache: dict[Path, str] = {}
+        self.records: list[Record] = []
+        self.records_by_id: dict[str, Record] = {}
+        self.record_counts: dict[Path, int] = defaultdict(int)
+        self.file_categories: dict[Path, str] = {}
+        self.profiles: list[Profile] = []
+
+    def _relative(self, path: object) -> str:
+        if isinstance(path, Path):
+            candidate = path.resolve(strict=False)
+            try:
+                return candidate.relative_to(self.repository).as_posix() or "."
+            except ValueError:
+                return str(path)
+        return str(path)
+
+    def _add(
+        self,
+        severity: str,
+        code: str,
+        path: object,
+        message: str,
+        line: int | None = None,
+    ) -> None:
+        relative = self._relative(path)
+        key = (severity, code, relative, line, message)
+        if key in self._finding_keys:
+            return
+        self._finding_keys.add(key)
+        finding = Finding(severity, code, relative, line, message)
+        if severity == "error":
+            self.errors.append(finding)
+        else:
+            self.warnings.append(finding)
+
+    def error(
+        self, code: str, path: object, message: str, line: int | None = None
+    ) -> None:
+        self._add("error", code, path, message, line)
+
+    def warn(
+        self, code: str, path: object, message: str, line: int | None = None
+    ) -> None:
+        self._add("warning", code, path, message, line)
+
+    def _read(self, path: Path) -> str:
+        resolved = path.resolve()
+        if resolved not in self._text_cache:
+            try:
+                self._text_cache[resolved] = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as exc:
+                raise InputError(f"cannot read {path}: {exc}") from exc
+        return self._text_cache[resolved]
+
+    def run(self) -> None:
+        self._check_required_routers()
+        document_files = self._document_files()
+        self._check_links(document_files)
+        self._discover_profiles()
+        self._parse_records()
+        self._validate_record_locations()
+        self._validate_records()
+        self._check_context_topics()
+        self._check_sizes(document_files)
+        self._check_duplicate_paragraphs(document_files)
+        self._check_artifacts()
+        self._check_boundary_routers()
+        self._check_baselined_placeholders()
+        self.errors.sort(key=lambda item: (item.path, item.line or 0, item.code))
+        self.warnings.sort(key=lambda item: (item.path, item.line or 0, item.code))
+
+    def _check_required_routers(self) -> None:
+        required = [
+            (
+                self.repository / "AGENTS.md",
+                "file",
+                "missing_root_router",
+                "required root AGENTS.md is missing",
+            ),
+            (
+                self.repository / ".agents",
+                "directory",
+                "missing_agents_directory",
+                "required .agents directory is missing",
+            ),
+            (
+                self.repository / ".agents" / "index.md",
+                "file",
+                "missing_agents_router",
+                "required .agents/index.md router is missing",
+            ),
+            (
+                self.repository / ".agents" / "v-model",
+                "directory",
+                "missing_vmodel_directory",
+                "required .agents/v-model directory is missing",
+            ),
+            (
+                self.repository / ".agents" / "v-model" / "index.md",
+                "file",
+                "missing_vmodel_router",
+                "required .agents/v-model/index.md router is missing",
+            ),
+        ]
+        for path, expected_type, code, message in required:
+            valid = path.is_file() if expected_type == "file" else path.is_dir()
+            if not valid:
+                self.error(code, path, message)
+        for source_root in self.source_roots:
+            router = source_root / "AGENTS.md"
+            if not router.is_file():
+                self.error(
+                    "missing_source_router",
+                    router,
+                    f"code root {self._relative(source_root)} requires AGENTS.md",
+                )
+
+    def _document_files(self) -> list[Path]:
+        files: set[Path] = set()
+        for directory, names, filenames in os.walk(self.repository, followlinks=False):
+            names[:] = [name for name in names if name not in SKIPPED_DIRS]
+            if "AGENTS.md" in filenames:
+                files.add(Path(directory) / "AGENTS.md")
+        agents_directory = self.repository / ".agents"
+        if agents_directory.is_dir():
+            try:
+                files.update(
+                    path for path in agents_directory.rglob("*.md") if path.is_file()
+                )
+            except OSError as exc:
+                raise InputError(f"cannot inspect {agents_directory}: {exc}") from exc
+        return sorted(files)
+
+    def _check_links(self, files: Iterable[Path]) -> None:
+        external_schemes = {"data", "ftp", "http", "https", "mailto", "tel"}
+        for path in files:
+            lines = _visible_lines(self._read(path))
+            for line_number, line in enumerate(lines, 1):
+                destinations = [match.group(1) for match in LINK_RE.finditer(line)]
+                reference_match = REFERENCE_LINK_RE.match(line)
+                if reference_match:
+                    destinations.append(reference_match.group(1))
+                for raw_destination in destinations:
+                    raw = raw_destination.strip()
+                    if raw.startswith("<") and raw.endswith(">"):
+                        destination = raw[1:-1].strip()
+                    else:
+                        destination = raw.split(maxsplit=1)[0]
+                    if not destination or destination.startswith("#"):
+                        continue
+                    if destination.startswith("//"):
+                        continue
+                    try:
+                        parsed = urlsplit(destination)
+                    except ValueError:
+                        self.error(
+                            "malformed_link",
+                            path,
+                            f"cannot parse local link destination {destination!r}",
+                            line_number,
+                        )
+                        continue
+                    if parsed.scheme.lower() in external_schemes or parsed.netloc:
+                        continue
+                    if parsed.scheme and len(parsed.scheme) > 1:
+                        continue
+                    local_path = unquote(parsed.path)
+                    if not local_path:
+                        continue
+                    if local_path.startswith("/"):
+                        candidate = self.repository / local_path.lstrip("/")
+                    else:
+                        candidate = path.parent / local_path
+                    resolved = candidate.resolve(strict=False)
+                    if not _is_within(resolved, self.repository):
+                        self.error(
+                            "escaping_link",
+                            path,
+                            f"local link escapes the repository: {destination}",
+                            line_number,
+                        )
+                    elif not candidate.exists():
+                        self.error(
+                            "broken_link",
+                            path,
+                            f"local link target does not exist: {destination}",
+                            line_number,
+                        )
+
+    def _discover_profiles(self) -> None:
+        vmodel_root = self.repository / ".agents" / "v-model"
+        if not vmodel_root.is_dir():
+            return
+        directories = [vmodel_root]
+        try:
+            directories.extend(path for path in vmodel_root.rglob("*") if path.is_dir())
+        except OSError as exc:
+            raise InputError(f"cannot inspect {vmodel_root}: {exc}") from exc
+        profile_roots = [
+            directory
+            for directory in directories
+            if any(
+                (directory / f"{entry}.md").exists() or (directory / entry).is_dir()
+                for entry in LAYER_ENTRIES
+            )
+        ]
+        if not profile_roots:
+            self.error(
+                "missing_vmodel_profile",
+                vmodel_root,
+                "no complete V-model profile entries were found",
+            )
+            return
+        for profile_root in sorted(set(profile_roots)):
+            files: set[Path] = set()
+            index = profile_root / "index.md"
+            if not index.is_file():
+                self.error(
+                    "missing_profile_router",
+                    index,
+                    "each product profile requires index.md",
+                )
+            else:
+                files.add(index.resolve())
+            for entry, category in LAYER_ENTRIES.items():
+                file_path = profile_root / f"{entry}.md"
+                directory_path = profile_root / entry
+                if file_path.exists() and directory_path.exists():
+                    self.error(
+                        "ambiguous_layer_storage",
+                        profile_root,
+                        f"use either {entry}.md or {entry}/, not both",
+                    )
+                if file_path.is_file():
+                    resolved = file_path.resolve()
+                    files.add(resolved)
+                    self.file_categories[resolved] = category
+                elif directory_path.is_dir():
+                    layer_index = directory_path / "index.md"
+                    if not layer_index.is_file():
+                        self.error(
+                            "missing_layer_router",
+                            layer_index,
+                            f"sharded layer {entry}/ requires index.md",
+                        )
+                    else:
+                        files.add(layer_index.resolve())
+                    try:
+                        shards = [
+                            path
+                            for path in directory_path.rglob("*.md")
+                            if path.is_file() and path.name != "index.md"
+                        ]
+                    except OSError as exc:
+                        raise InputError(
+                            f"cannot inspect sharded layer {directory_path}: {exc}"
+                        ) from exc
+                    for shard in shards:
+                        resolved = shard.resolve()
+                        files.add(resolved)
+                        self.file_categories[resolved] = category
+                else:
+                    self.error(
+                        "missing_profile_layer",
+                        file_path,
+                        f"profile requires {entry}.md or {entry}/",
+                    )
+            status = self._profile_status(index) if index.is_file() else None
+            self.profiles.append(Profile(profile_root.resolve(), files, status))
+
+    def _profile_status(self, index: Path) -> str | None:
+        pattern = re.compile(
+            r"^\s*[-*]\s+\*\*Profile status:\*\*\s*(.+?)\s*$", re.IGNORECASE
+        )
+        for line_number, line in enumerate(_visible_lines(self._read(index)), 1):
+            match = pattern.match(line)
+            if match:
+                status = _clean_scalar(match.group(1))
+                if status not in {"draft", "baselined"}:
+                    self.error(
+                        "invalid_profile_status",
+                        index,
+                        "Profile status must be draft or baselined",
+                        line_number,
+                    )
+                return status
+        self.warn(
+            "missing_profile_status",
+            index,
+            "profile index should declare Profile status as draft or baselined",
+        )
+        return None
+
+    def _parse_records(self) -> None:
+        vmodel_root = self.repository / ".agents" / "v-model"
+        if not vmodel_root.is_dir():
+            return
+        try:
+            files = sorted(path for path in vmodel_root.rglob("*.md") if path.is_file())
+        except OSError as exc:
+            raise InputError(f"cannot inspect {vmodel_root}: {exc}") from exc
+        for path in files:
+            lines = _visible_lines(self._read(path))
+            candidates: list[tuple[int, re.Match[str]]] = []
+            for index, line in enumerate(lines):
+                match = HEADING_CANDIDATE_RE.match(line)
+                if match:
+                    candidates.append((index, match))
+            for candidate_index, (start, match) in enumerate(candidates):
+                identifier = match.group(2).rstrip(".,;")
+                line_number = start + 1
+                if len(match.group(1)) < 2:
+                    self.error(
+                        "invalid_record_heading_level",
+                        path,
+                        f"{identifier} must use a level-two or deeper heading",
+                        line_number,
+                    )
+                if not VALID_ID_RE.fullmatch(identifier):
+                    self.error(
+                        "malformed_id",
+                        path,
+                        f"malformed record ID {identifier!r}; use PREFIX-###",
+                        line_number,
+                    )
+                    continue
+                raw_title = match.group(3) or ""
+                title = re.sub(r"^[\s—–:|-]+", "", raw_title).strip()
+                if not title:
+                    self.error(
+                        "missing_record_title",
+                        path,
+                        f"{identifier} requires a concise title",
+                        line_number,
+                    )
+                end = (
+                    candidates[candidate_index + 1][0]
+                    if candidate_index + 1 < len(candidates)
+                    else len(lines)
+                )
+                fields, field_lines = self._parse_fields(
+                    path, lines[start + 1 : end], start + 2
+                )
+                record = Record(
+                    identifier, title, path.resolve(), line_number, fields, field_lines
+                )
+                self.records.append(record)
+                self.record_counts[path.resolve()] += 1
+                if identifier in self.records_by_id:
+                    first = self.records_by_id[identifier]
+                    first_location = f"{self._relative(first.path)}:{first.line}"
+                    self.error(
+                        "duplicate_id",
+                        path,
+                        f"{identifier} duplicates {first_location}",
+                        line_number,
+                    )
+                else:
+                    self.records_by_id[identifier] = record
+
+    def _parse_fields(
+        self, path: Path, lines: Sequence[str], first_line: int
+    ) -> tuple[dict[str, str], dict[str, int]]:
+        fields: dict[str, str] = {}
+        field_lines: dict[str, int] = {}
+        active: str | None = None
+        values: list[str] = []
+
+        def flush() -> None:
+            nonlocal active, values
+            if active is not None:
+                fields[active] = " ".join(
+                    part.strip() for part in values if part.strip()
+                )
+            active = None
+            values = []
+
+        for offset, line in enumerate(lines):
+            line_number = first_line + offset
+            match = FIELD_RE.match(line)
+            if match:
+                flush()
+                name = _normalize_field(match.group(1))
+                if name in fields or name in field_lines:
+                    self.error(
+                        "duplicate_field",
+                        path,
+                        f"record field {match.group(1)!r} appears more than once",
+                        line_number,
+                    )
+                active = name
+                field_lines[name] = line_number
+                values = [match.group(2)]
+            elif not line.strip() or line.lstrip().startswith("#"):
+                flush()
+            elif active is not None:
+                values.append(line)
+        flush()
+        return fields, field_lines
+
+    def _validate_record_locations(self) -> None:
+        for record in self.records:
+            category = self.file_categories.get(record.path)
+            expected = "ACTION" if record.prefix in ACTION_PREFIXES else record.prefix
+            if category is None:
+                message = (
+                    f"{record.identifier} is outside its canonical layer "
+                    "or verification shard"
+                )
+                self.error(
+                    "record_outside_layer",
+                    record.path,
+                    message,
+                    record.line,
+                )
+            elif category != expected:
+                self.error(
+                    "record_wrong_layer",
+                    record.path,
+                    f"{record.identifier} belongs in {expected}, not {category}",
+                    record.line,
+                )
+
+    def _validate_records(self) -> None:
+        specifications = [
+            record for record in self.records if record.prefix in SPEC_PREFIXES
+        ]
+        actions = [
+            record for record in self.records if record.prefix in ACTION_PREFIXES
+        ]
+        spec_verifications: dict[str, dict[str, str]] = {}
+        action_coverage: dict[str, set[str]] = {}
+
+        for record in specifications:
+            self._require_fields(record, SPEC_REQUIRED_FIELDS)
+            self._check_reference_tokens(record, ("parents", "verification"))
+            self._validate_parents(record)
+            spec_verifications[record.identifier] = self._verification_mappings(record)
+
+        for record in actions:
+            self._require_fields(record, ACTION_REQUIRED_FIELDS)
+            self._check_reference_tokens(record, ("covers",))
+            action_coverage[record.identifier] = self._validate_action(record)
+
+        for spec_id, mappings in spec_verifications.items():
+            specification = self.records_by_id.get(spec_id)
+            if specification is None:
+                continue
+            for action_id, declared_method in mappings.items():
+                action = self.records_by_id.get(action_id)
+                if action is None or action.prefix not in ACTION_PREFIXES:
+                    self.error(
+                        "unknown_verification_action",
+                        specification.path,
+                        f"{spec_id} references missing action {action_id}",
+                        specification.field_lines.get(
+                            "verification", specification.line
+                        ),
+                    )
+                    continue
+                if spec_id not in action_coverage.get(action_id, set()):
+                    message = (
+                        f"{spec_id} lists {action_id}, but {action_id} "
+                        f"does not cover {spec_id}"
+                    )
+                    self.error(
+                        "nonbidirectional_trace",
+                        specification.path,
+                        message,
+                        specification.field_lines.get(
+                            "verification", specification.line
+                        ),
+                    )
+                action_method = _clean_scalar(action.fields.get("method", ""))
+                if action_method in METHODS and declared_method != action_method:
+                    self.error(
+                        "trace_method_mismatch",
+                        specification.path,
+                        f"{spec_id} declares {action_id} as {declared_method}, "
+                        f"but the action method is {action_method}",
+                        specification.field_lines.get(
+                            "verification", specification.line
+                        ),
+                    )
+
+        for action_id, covered_ids in action_coverage.items():
+            action = self.records_by_id.get(action_id)
+            if action is None:
+                continue
+            for spec_id in covered_ids:
+                specification = self.records_by_id.get(spec_id)
+                if specification is None or specification.prefix not in SPEC_PREFIXES:
+                    continue
+                if action_id not in spec_verifications.get(spec_id, {}):
+                    message = (
+                        f"{action_id} covers {spec_id}, but {spec_id} "
+                        f"does not list {action_id}"
+                    )
+                    self.error(
+                        "nonbidirectional_trace",
+                        action.path,
+                        message,
+                        action.field_lines.get("covers", action.line),
+                    )
+
+    def _require_fields(self, record: Record, required: set[str]) -> None:
+        for field in sorted(required):
+            if field not in record.fields or not record.fields[field].strip():
+                self.error(
+                    "missing_record_field",
+                    record.path,
+                    f"{record.identifier} requires field {field!r}",
+                    record.line,
+                )
+
+    def _check_reference_tokens(
+        self, record: Record, field_names: Sequence[str]
+    ) -> None:
+        for field_name in field_names:
+            value = record.fields.get(field_name, "")
+            for match in ID_CANDIDATE_RE.finditer(value):
+                candidate = match.group(0).rstrip(".,;")
+                if not VALID_ID_RE.fullmatch(candidate):
+                    self.error(
+                        "malformed_id",
+                        record.path,
+                        f"malformed ID {candidate!r} in {field_name}",
+                        record.field_lines.get(field_name, record.line),
+                    )
+
+    def _validate_parents(self, record: Record) -> None:
+        value = record.fields.get("parents", "")
+        parent_ids = VALID_ID_FIND_RE.findall(value)
+        expected_prefix = EXPECTED_PARENT[record.prefix]
+        if expected_prefix is None:
+            if parent_ids or (value and not _is_none(value)):
+                message = (
+                    f"{record.identifier} is a stakeholder outcome and "
+                    "must have Parents: None"
+                )
+                self.error(
+                    "invalid_parent_layer",
+                    record.path,
+                    message,
+                    record.field_lines.get("parents", record.line),
+                )
+            return
+        if not parent_ids:
+            self.error(
+                "missing_parent",
+                record.path,
+                f"{record.identifier} requires at least one {expected_prefix} parent",
+                record.field_lines.get("parents", record.line),
+            )
+            return
+        for parent_id in parent_ids:
+            parent_prefix = parent_id.split("-", 1)[0]
+            if parent_prefix != expected_prefix:
+                message = (
+                    f"{record.identifier} may reference only "
+                    f"{expected_prefix} parents, not {parent_id}"
+                )
+                self.error(
+                    "invalid_parent_layer",
+                    record.path,
+                    message,
+                    record.field_lines.get("parents", record.line),
+                )
+            parent = self.records_by_id.get(parent_id)
+            if parent is None or parent.prefix not in SPEC_PREFIXES:
+                self.error(
+                    "unknown_parent",
+                    record.path,
+                    f"{record.identifier} references missing parent {parent_id}",
+                    record.field_lines.get("parents", record.line),
+                )
+
+    def _verification_mappings(self, record: Record) -> dict[str, str]:
+        value = record.fields.get("verification", "")
+        action_ids = [
+            identifier
+            for identifier in VALID_ID_FIND_RE.findall(value)
+            if identifier.split("-", 1)[0] in ACTION_PREFIXES
+        ]
+        all_ids = VALID_ID_FIND_RE.findall(value)
+        for identifier in all_ids:
+            if identifier.split("-", 1)[0] in SPEC_PREFIXES:
+                message = (
+                    f"{record.identifier} verification field contains "
+                    f"specification {identifier}"
+                )
+                self.error(
+                    "invalid_verification_reference",
+                    record.path,
+                    message,
+                    record.field_lines.get("verification", record.line),
+                )
+        if not action_ids:
+            self.error(
+                "unmapped_specification",
+                record.path,
+                f"{record.identifier} has no right-side verification action",
+                record.field_lines.get("verification", record.line),
+            )
+            return {}
+        mappings: dict[str, str] = {}
+        expected_prefix = EXPECTED_ACTION[record.prefix]
+        for action_id in action_ids:
+            action_prefix = action_id.split("-", 1)[0]
+            if action_prefix != expected_prefix:
+                message = (
+                    f"{record.identifier} must map to {expected_prefix}, "
+                    f"not {action_id}"
+                )
+                self.error(
+                    "invalid_action_layer",
+                    record.path,
+                    message,
+                    record.field_lines.get("verification", record.line),
+                )
+            method_match = re.search(
+                rf"\b{re.escape(action_id)}\s*\(\s*"
+                r"(test|analysis|inspection|demonstration)\s*\)",
+                value,
+                re.IGNORECASE,
+            )
+            if method_match is None:
+                self.error(
+                    "missing_mapping_method",
+                    record.path,
+                    f"{action_id} must include its method in parentheses",
+                    record.field_lines.get("verification", record.line),
+                )
+            else:
+                mappings[action_id] = method_match.group(1).lower()
+        return mappings
+
+    def _validate_action(self, record: Record) -> set[str]:
+        covers_value = record.fields.get("covers", "")
+        covered_ids = {
+            identifier
+            for identifier in VALID_ID_FIND_RE.findall(covers_value)
+            if identifier.split("-", 1)[0] in SPEC_PREFIXES
+        }
+        for identifier in VALID_ID_FIND_RE.findall(covers_value):
+            if identifier.split("-", 1)[0] in ACTION_PREFIXES:
+                self.error(
+                    "invalid_covered_reference",
+                    record.path,
+                    f"{record.identifier} Covers contains action {identifier}",
+                    record.field_lines.get("covers", record.line),
+                )
+        if not covered_ids:
+            self.error(
+                "action_without_specification",
+                record.path,
+                f"{record.identifier} covers no specification",
+                record.field_lines.get("covers", record.line),
+            )
+        expected_spec = EXPECTED_SPEC[record.prefix]
+        for spec_id in sorted(covered_ids):
+            spec_prefix = spec_id.split("-", 1)[0]
+            if spec_prefix != expected_spec:
+                message = (
+                    f"{record.identifier} may cover only {expected_spec}, not {spec_id}"
+                )
+                self.error(
+                    "invalid_action_layer",
+                    record.path,
+                    message,
+                    record.field_lines.get("covers", record.line),
+                )
+            specification = self.records_by_id.get(spec_id)
+            if specification is None or specification.prefix not in SPEC_PREFIXES:
+                self.error(
+                    "unknown_covered_specification",
+                    record.path,
+                    f"{record.identifier} references missing specification {spec_id}",
+                    record.field_lines.get("covers", record.line),
+                )
+        method = _clean_scalar(record.fields.get("method", ""))
+        if method not in METHODS:
+            methods = ", ".join(sorted(METHODS))
+            self.error(
+                "invalid_verification_method",
+                record.path,
+                f"{record.identifier} Method must be one of {methods}",
+                record.field_lines.get("method", record.line),
+            )
+        status = _clean_scalar(record.fields.get("status", ""))
+        if status not in STATUSES:
+            statuses = ", ".join(sorted(STATUSES))
+            self.error(
+                "invalid_verification_status",
+                record.path,
+                f"{record.identifier} Status must be one of {statuses}",
+                record.field_lines.get("status", record.line),
+            )
+        if status == "passing" and not self._durable_evidence(
+            record.fields.get("evidence", "")
+        ):
+            self.error(
+                "passing_without_evidence",
+                record.path,
+                f"{record.identifier} is passing without a durable evidence reference",
+                record.field_lines.get("evidence", record.line),
+            )
+        return covered_ids
+
+    @staticmethod
+    def _durable_evidence(value: str) -> bool:
+        if _is_none(value) or PLACEHOLDER_RE.search(value):
+            return False
+        return bool(
+            re.search(r"\[[^\]]+\]\([^)]+\)", value)
+            or re.search(r"`[^`]+`", value)
+            or re.search(r"https?://\S+", value)
+            or re.search(
+                r"(?:^|\s)(?:artifacts?|docs?|reports?|test|tests|ci)/\S+", value
+            )
+        )
+
+    def _check_context_topics(self) -> None:
+        context_root = self.repository / ".agents" / "context"
+        if not context_root.is_dir():
+            return
+        try:
+            topics = [
+                path
+                for path in context_root.rglob("*.md")
+                if path.is_file() and path.name != "index.md"
+            ]
+        except OSError as exc:
+            raise InputError(f"cannot inspect {context_root}: {exc}") from exc
+        reachable_topics = self._reachable_context_topics(context_root)
+        for topic in sorted(topics):
+            lines = _visible_lines(self._read(topic))
+            metadata = self._context_metadata(lines)
+            self._check_context_metadata(topic, metadata)
+            text = "\n".join(lines)
+            specification_ids = {
+                identifier
+                for identifier in VALID_ID_FIND_RE.findall(text)
+                if identifier.split("-", 1)[0] in SPEC_PREFIXES
+            }
+            if not specification_ids and not self._has_justified_missing_specification(
+                metadata
+            ):
+                self.warn(
+                    "context_without_specification",
+                    topic,
+                    "context topic does not link to a specification ID",
+                )
+            for identifier in sorted(specification_ids):
+                record = self.records_by_id.get(identifier)
+                if record is None or record.prefix not in SPEC_PREFIXES:
+                    self.warn(
+                        "context_unknown_specification",
+                        topic,
+                        f"context topic references missing specification {identifier}",
+                    )
+            if topic.resolve() not in reachable_topics:
+                self.warn(
+                    "unreachable_context_topic",
+                    topic,
+                    "context topic is not reachable from .agents/index.md "
+                    "through linked context index files",
+                )
+
+    @staticmethod
+    def _context_metadata(
+        lines: Sequence[str],
+    ) -> dict[str, list[tuple[int, str]]]:
+        metadata: dict[str, list[tuple[int, str]]] = defaultdict(list)
+        for line_number, line in enumerate(lines, 1):
+            if H2_RE.match(line):
+                break
+            match = FIELD_RE.match(line)
+            if match is None:
+                continue
+            name = _normalize_field(match.group(1))
+            if name in CONTEXT_METADATA_FIELDS:
+                metadata[name].append((line_number, match.group(2).strip()))
+        return dict(metadata)
+
+    def _check_context_metadata(
+        self,
+        topic: Path,
+        metadata: dict[str, list[tuple[int, str]]],
+    ) -> None:
+        need_entries = metadata.get("context need", [])
+        nonempty_needs = [
+            (line_number, value) for line_number, value in need_entries if value.strip()
+        ]
+        if not nonempty_needs:
+            self.warn(
+                "missing_context_need",
+                topic,
+                "context topic should declare Context need before its first "
+                "level-two heading",
+                need_entries[0][0] if need_entries else None,
+            )
+        else:
+            line_number, value = nonempty_needs[0]
+            normalized = re.sub(
+                r"\s+", " ", value.strip().strip("`*_").strip()
+            ).casefold()
+            if normalized not in CONTEXT_NEEDS:
+                choices = ", ".join(CONTEXT_NEEDS.values())
+                self.warn(
+                    "invalid_context_need",
+                    topic,
+                    f"Context need must be one of: {choices}",
+                    line_number,
+                )
+        for line_number, _ in need_entries[1:]:
+            self.warn(
+                "duplicate_context_need",
+                topic,
+                "Context need appears more than once before the first "
+                "level-two heading",
+                line_number,
+            )
+
+        for field, code, label in (
+            ("open when", "missing_context_open_when", "Open when"),
+            (
+                "do not open when",
+                "missing_context_do_not_open_when",
+                "Do not open when",
+            ),
+            (
+                "related specification ids",
+                "missing_context_related_specification_ids",
+                "Related specification IDs",
+            ),
+            ("review when", "missing_context_review_when", "Review when"),
+        ):
+            entries = metadata.get(field, [])
+            if not any(value.strip() for _, value in entries):
+                self.warn(
+                    code,
+                    topic,
+                    f"context topic should declare {label} before its first "
+                    "level-two heading",
+                    entries[0][0] if entries else None,
+                )
+
+    @staticmethod
+    def _has_justified_missing_specification(
+        metadata: dict[str, list[tuple[int, str]]],
+    ) -> bool:
+        return any(
+            JUSTIFIED_CONTEXT_WITHOUT_SPEC_RE.fullmatch(
+                value.strip().strip("`*_").strip()
+            )
+            is not None
+            for _, value in metadata.get("related specification ids", [])
+        )
+
+    def _reachable_context_topics(self, context_root: Path) -> set[Path]:
+        root_index = self.repository / ".agents" / "index.md"
+        if not root_index.is_file():
+            return set()
+        resolved_context_root = context_root.resolve()
+        pending = [(root_index.resolve(), 0)]
+        visited_depths: dict[Path, int] = {}
+        reachable: set[Path] = set()
+        while pending:
+            router, depth = pending.pop()
+            if depth >= visited_depths.get(router, depth + 1):
+                continue
+            visited_depths[router] = depth
+            context_targets = {
+                target
+                for target in self._linked_local_files(router)
+                if _is_within(target, resolved_context_root)
+                and (target.name == "index.md" or target.suffix.lower() == ".md")
+            }
+            if len(context_targets) > 7:
+                self.warn(
+                    "context_router_choice_budget",
+                    router,
+                    f"context index presents {len(context_targets)} choices; "
+                    "use at most 7",
+                )
+            for target in context_targets:
+                if target.name == "index.md":
+                    next_depth = depth + 1
+                    if next_depth > 1:
+                        self.warn(
+                            "context_router_depth_budget",
+                            router,
+                            f"context index links to nested router "
+                            f"{self._relative(target)} beyond the one-hop budget",
+                        )
+                    pending.append((target, next_depth))
+                else:
+                    reachable.add(target)
+        return reachable
+
+    def _linked_local_files(self, path: Path) -> set[Path]:
+        external_schemes = {"data", "ftp", "http", "https", "mailto", "tel"}
+        targets: set[Path] = set()
+        for line in _visible_lines(self._read(path)):
+            destinations = [match.group(1) for match in LINK_RE.finditer(line)]
+            reference_match = REFERENCE_LINK_RE.match(line)
+            if reference_match:
+                destinations.append(reference_match.group(1))
+            for raw_destination in destinations:
+                raw = raw_destination.strip()
+                if raw.startswith("<") and raw.endswith(">"):
+                    destination = raw[1:-1].strip()
+                else:
+                    destination = raw.split(maxsplit=1)[0]
+                if not destination or destination.startswith(("#", "//")):
+                    continue
+                try:
+                    parsed = urlsplit(destination)
+                except ValueError:
+                    continue
+                if parsed.scheme.lower() in external_schemes or parsed.netloc:
+                    continue
+                if parsed.scheme and len(parsed.scheme) > 1:
+                    continue
+                local_path = unquote(parsed.path)
+                if not local_path:
+                    continue
+                if local_path.startswith("/"):
+                    candidate = self.repository / local_path.lstrip("/")
+                else:
+                    candidate = path.parent / local_path
+                resolved = candidate.resolve(strict=False)
+                if _is_within(resolved, self.repository) and candidate.is_file():
+                    targets.add(resolved)
+        return targets
+
+    def _check_sizes(self, document_files: Iterable[Path]) -> None:
+        for path in document_files:
+            text = self._read(path)
+            line_count = len(text.splitlines())
+            word_count = len(WORD_RE.findall(text))
+            record_count = self.record_counts.get(path.resolve(), 0)
+            if path.resolve() == (self.repository / "AGENTS.md").resolve():
+                limits = (100, 700, None, "root AGENTS.md")
+            elif path.name == "AGENTS.md":
+                limits = (40, 250, None, "nested AGENTS.md")
+            elif (
+                _is_within(path.resolve(), (self.repository / ".agents").resolve())
+                and path.name == "index.md"
+            ):
+                limits = (100, 600, None, "router index")
+            elif _is_within(path.resolve(), (self.repository / ".agents").resolve()):
+                limits = (200, 1200, 40, "detail or V-model shard")
+            else:
+                continue
+            line_limit, word_limit, record_limit, label = limits
+            exceeded = []
+            if line_count > line_limit:
+                exceeded.append(f"{line_count} lines > {line_limit}")
+            if word_count > word_limit:
+                exceeded.append(f"{word_count} words > {word_limit}")
+            if record_limit is not None and record_count > record_limit:
+                exceeded.append(f"{record_count} records > {record_limit}")
+            if exceeded:
+                self.warn(
+                    "size_budget",
+                    path,
+                    f"{label} exceeds warning budget: {', '.join(exceeded)}",
+                )
+
+    def _check_duplicate_paragraphs(self, document_files: Iterable[Path]) -> None:
+        occurrences: dict[str, list[tuple[Path, int]]] = defaultdict(list)
+        for path in document_files:
+            lines = _visible_lines(self._read(path))
+            block: list[tuple[int, str]] = []
+            for line_number, line in enumerate(lines + [""], 1):
+                if line.strip():
+                    block.append((line_number, line))
+                elif block:
+                    normalized = _normalized_paragraph(block)
+                    if normalized is not None:
+                        occurrences[normalized].append((path, block[0][0]))
+                    block = []
+        for locations in occurrences.values():
+            unique = {(path.resolve(), line) for path, line in locations}
+            if len(unique) < 2:
+                continue
+            ordered = sorted(unique, key=lambda item: (str(item[0]), item[1]))
+            display = ", ".join(
+                f"{self._relative(path)}:{line}" for path, line in ordered[:4]
+            )
+            if len(ordered) > 4:
+                display += f", and {len(ordered) - 4} more"
+            first_path, first_line = ordered[0]
+            message = (
+                "identical normalized paragraph of at least 40 words "
+                f"appears at {display}"
+            )
+            self.warn(
+                "duplicate_paragraph",
+                first_path,
+                message,
+                first_line,
+            )
+
+    def _check_artifacts(self) -> None:
+        agents_root = self.repository / ".agents"
+        if not agents_root.is_dir():
+            return
+        try:
+            files = [path for path in agents_root.rglob("*") if path.is_file()]
+        except OSError as exc:
+            raise InputError(f"cannot inspect {agents_root}: {exc}") from exc
+        for path in sorted(files):
+            try:
+                size = path.stat().st_size
+            except OSError as exc:
+                raise InputError(f"cannot stat {path}: {exc}") from exc
+            reasons = []
+            if path.suffix.lower() in ARTIFACT_SUFFIXES:
+                reasons.append(f"{path.suffix or 'binary'} artifact")
+            if size > 256 * 1024:
+                reasons.append(f"{size} bytes")
+            if reasons:
+                self.warn(
+                    "non_context_artifact",
+                    path,
+                    "large or generated artifact under .agents: " + ", ".join(reasons),
+                )
+
+    def _check_boundary_routers(self) -> None:
+        for source_root in self.source_roots:
+            if not source_root.is_dir():
+                continue
+            for directory, names, filenames in os.walk(source_root, followlinks=False):
+                names[:] = [name for name in names if name not in BOUNDARY_SKIPPED_DIRS]
+                path = Path(directory)
+                try:
+                    depth = len(path.relative_to(source_root).parts)
+                except ValueError:
+                    continue
+                if depth > 3:
+                    names[:] = []
+                    continue
+                if path == source_root or "AGENTS.md" in filenames:
+                    continue
+                direct_code = sum(
+                    Path(filename).suffix.lower() in CODE_SUFFIXES
+                    for filename in filenames
+                )
+                child_code_dirs = 0
+                for child_name in names:
+                    child = path / child_name
+                    try:
+                        if any(
+                            item.is_file() and item.suffix.lower() in CODE_SUFFIXES
+                            for item in child.iterdir()
+                        ):
+                            child_code_dirs += 1
+                    except OSError as exc:
+                        raise InputError(f"cannot inspect {child}: {exc}") from exc
+                has_marker = any(marker in filenames for marker in BOUNDARY_MARKERS)
+                appears_meaningful = (
+                    (has_marker and (direct_code >= 1 or child_code_dirs >= 1))
+                    or (direct_code >= 1 and child_code_dirs >= 2)
+                    or child_code_dirs >= 3
+                )
+                if appears_meaningful:
+                    self.warn(
+                        "missing_boundary_router",
+                        path / "AGENTS.md",
+                        f"{self._relative(path)} appears to be a meaningful source "
+                        "boundary but has no AGENTS.md",
+                    )
+
+    def _check_baselined_placeholders(self) -> None:
+        for profile in self.profiles:
+            if profile.status != "baselined":
+                continue
+            for path in sorted(profile.files):
+                if not path.is_file():
+                    continue
+                for line_number, line in enumerate(_visible_lines(self._read(path)), 1):
+                    match = PLACEHOLDER_RE.search(line)
+                    if match:
+                        self.warn(
+                            "baselined_placeholder",
+                            path,
+                            f"baselined profile contains unresolved placeholder "
+                            f"{match.group(0)!r}",
+                            line_number,
+                        )
+
+    def result(self, fail_on_warn: bool) -> dict[str, object]:
+        exit_code = 1 if self.errors or (fail_on_warn and self.warnings) else 0
+        return {
+            "repository": str(self.repository),
+            "source_roots": [self._relative(path) for path in self.source_roots],
+            "errors": [finding.as_dict() for finding in self.errors],
+            "warnings": [finding.as_dict() for finding in self.warnings],
+            "summary": {
+                "errors": len(self.errors),
+                "warnings": len(self.warnings),
+                "exit_code": exit_code,
+            },
+        }
+
+
+def _resolve_source_roots(repository: Path, values: Sequence[str] | None) -> list[Path]:
+    if values is None:
+        default = repository / "src"
+        if not default.is_dir():
+            return []
+        resolved = default.resolve()
+        if not _is_within(resolved, repository):
+            raise InputError("default source root src escapes repository")
+        return [resolved]
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for value in values:
+        raw = Path(value)
+        candidate = raw if raw.is_absolute() else repository / raw
+        resolved = candidate.resolve(strict=False)
+        if not _is_within(resolved, repository):
+            raise InputError(f"source root escapes repository: {value}")
+        if not candidate.is_dir():
+            raise InputError(f"source root is not a readable directory: {value}")
+        if resolved not in seen:
+            seen.add(resolved)
+            roots.append(resolved)
+    return roots
+
+
+def _print_human(result: dict[str, object]) -> None:
+    print(f"Repository: {result['repository']}")
+    for group_name in ("errors", "warnings"):
+        findings = result[group_name]
+        assert isinstance(findings, list)
+        for finding in findings:
+            assert isinstance(finding, dict)
+            location = str(finding["path"])
+            if "line" in finding:
+                location += f":{finding['line']}"
+            print(
+                f"{str(finding['severity']).upper()} "
+                f"[{finding['code']}] {location}: {finding['message']}"
+            )
+    summary = result["summary"]
+    assert isinstance(summary, dict)
+    print(f"Summary: {summary['errors']} error(s), {summary['warnings']} warning(s)")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only integrity and size checks for repository agent documentation."
+        )
+    )
+    parser.add_argument("repository", help="repository root to inspect")
+    parser.add_argument(
+        "--source-root",
+        action="append",
+        metavar="PATH",
+        help="repository-relative code root; repeat for polyglot layouts",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit machine-readable JSON"
+    )
+    parser.add_argument(
+        "--fail-on-warn",
+        action="store_true",
+        help="return exit status 1 when warnings are present",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repository = Path(args.repository).expanduser()
+    if not repository.is_dir():
+        parser.error(f"repository is not a readable directory: {args.repository}")
+    repository = repository.resolve()
+    try:
+        source_roots = _resolve_source_roots(repository, args.source_root)
+        linter = RepositoryDocsLinter(repository, source_roots)
+        linter.run()
+        result = linter.result(args.fail_on_warn)
+    except InputError as exc:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "repository": str(repository),
+                        "input_error": str(exc),
+                        "summary": {"errors": 0, "warnings": 0, "exit_code": 2},
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(f"INPUT ERROR: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        _print_human(result)
+    summary = result["summary"]
+    assert isinstance(summary, dict)
+    return int(summary["exit_code"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a repository-neutral skill for agent-facing documentation and V-model traceability
- structure `.agents/context` around four agent-oriented Diátaxis needs with progressive disclosure
- add reusable templates and a dependency-free read-only documentation linter
- update the collection index

## Validation

- official skill quick validation
- Ruff lint and format checks
- temporary linter fixtures for metadata, traceability, routing, warning exits, and template materialization
- clean-room read-only forward tests on TermInterface, PBCCompiler, and WebQuantumSavory
- independent release review