### PR TITLE
Clarify temporary V-model lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ examples live in references that are loaded only for the current task.
 | [`orchestrate-julia-workloads`](orchestrate-julia-workloads/) | Tasks, channels, threads, synchronization, native-library thread control, and subprocesses |
 | [`handle-julia-data`](handle-julia-data/) | DataFrames/Tables workflows, delimited data, TOML/YAML configuration, and table reports |
 | [`build-julia-interfaces`](build-julia-interfaces/) | Scripts, Pkg apps, Comonicon CLIs, Term output/TUIs, and Makie recipes |
-| [`document-repository-v-model`](document-repository-v-model/) | Progressive repository guidance, structured V-model specifications, traceability, review, and compaction |
+| [`document-repository-v-model`](document-repository-v-model/) | Durable agent guidance plus temporary V-models for initial design and holistic review |
 
 ## Design
 

--- a/document-repository-v-model/SKILL.md
+++ b/document-repository-v-model/SKILL.md
@@ -1,94 +1,115 @@
 ---
 name: document-repository-v-model
-description: Build, migrate, audit, review, update, and compact agent-facing repository documentation with nested AGENTS.md routers, selectively loaded Diátaxis-style .agents context, structured V-model specifications, and bidirectional verification traceability. Use when creating documentation for a new or existing repository, migrating a monolithic AGENTS.md, defining or auditing V-model traceability, interviewing developers to recover intended behavior, adding nested AGENTS.md files, organizing agent context, reviewing .agents consistency, or compacting stale and duplicated repository context.
+description: "Create and audit durable agent-facing repository documentation. Use a temporary V-model only when interviewing a developer before code exists to turn a rough project prompt into a design independent agents can implement, or during a holistic codebase review to compare implementation with intended goals and expose design or implementation gaps. Also use when creating or migrating nested AGENTS.md routers and selectively loaded .agents context, or linting and compacting agent documentation."
 ---
 
 # Document Repository V-Model
 
-Create a small, navigable documentation system that separates normative product
-specification from implementation decisions. Treat the V-model as a general repository
-profile, not as a claim of NASA, FDA, ECSS, or V-Modell XT compliance.
+Build durable `AGENTS.md` routers and `.agents/context/` documentation. Create a V-model
+only as a temporary coordination artifact for an initial design or a holistic review.
 
 ## Start
 
 1. Read every applicable repository instruction before inspecting or changing files.
-2. Determine the repository boundary, worktree rules, code roots, existing documentation,
-   and whether the request is creation, migration, review, or update.
-3. Preserve useful material and user changes. Do not infer intended behavior from code or
-   tests alone.
-4. Keep normative behavior under `.agents/v-model/`; keep implementation-facing
-   learning, task, reference, and explanation material in `.agents/context/`.
-5. Load only the references needed for the selected workflow. Never recursively load the
-   entire `.agents/` tree.
+2. Establish the repository boundary, worktree rules, code roots, existing documentation,
+   and developer authority.
+3. Choose exactly one workflow:
+   - **Initial design:** no implementation exists yet; turn a rough prompt into an
+     implementation-ready design through developer interviews.
+   - **Holistic review:** compare an existing codebase with developer-confirmed goals to
+     find design defects and missing implementation.
+   - **Documentation maintenance:** improve persistent agent guidance without a V-model.
+4. Preserve useful material and user changes. Treat code and tests as evidence of current
+   behavior, not proof of intended behavior.
 
-## Select a Workflow
+Read [subagent playbooks](references/subagent-playbooks.md) only when delegation is
+permitted and the selected workflow benefits from independent lanes.
 
-- For a new repository, read [discovery and interviews](references/discovery-and-interviews.md),
-  interview in short rounds, confirm stakeholder outcomes before deriving requirements,
-  then add context and routers only as real boundaries emerge.
-- For an existing repository or monolithic guide, read
-  [discovery and interviews](references/discovery-and-interviews.md) and
-  [repository layout](references/repository-layout.md). Discover evidence read-only,
-  classify observed behavior, and baseline only confirmed intent.
-- For a consistency review or compaction, read
-  [review and compaction](references/review-and-compaction.md). Update canonical content
-  before shortening routers, then recheck links, traceability, and meaning.
-- For a feature or release update, run a mini-V: revise affected outcomes and requirements,
-  update contracts and verification actions, record implementation decisions separately,
-  and assess regression impact.
+Do not create or maintain a V-model for routine feature work, releases, or ordinary
+documentation updates. Once a codebase has been implemented and holistically reviewed,
+the cost and drift risk of a persistent parallel specification outweigh its value.
 
-Read [V-model and traceability](references/v-model-and-traceability.md) whenever creating,
-changing, or auditing specification records. Read
-[agent context documentation](references/agent-context-documentation.md) only when
-creating, migrating, splitting, reviewing, or compacting `.agents/context/`; skip it for
-router-only or V-model-only work. Read
-[subagent playbooks](references/subagent-playbooks.md) only when delegation is permitted
-and risk, scale, or requested independence justifies separate investigators or reviewers.
+## Run an Initial Design
 
-## Build the Documentation
+Read [discovery and interviews](references/discovery-and-interviews.md), then read
+[V-model and traceability](references/v-model-and-traceability.md).
+
+1. Before writing code, interview the developer in short rounds about users, scenarios,
+   boundaries, failure behavior, constraints, non-goals, interfaces, and acceptance.
+2. Draft and confirm a temporary `.agents/v-model/` that makes the rough prompt precise
+   enough for independent agents to implement nonoverlapping parts.
+3. Plan objective verification with the requirements. Keep implementation choices and
+   working instructions in `.agents/context/`, not in normative records.
+4. Develop the persistent routers and context while implementation proceeds.
+5. Reconcile the implementation, verification evidence, and developer intent.
+6. Move durable usage and development knowledge into agent documentation. Record any
+   unfinished behavior there as brief, actionable current gaps.
+7. Delete `.agents/v-model/` and every link or ID that depends on it before final handoff.
+
+The V-model may be committed on a task branch so several agents can coordinate, but it
+must not remain in the completed repository state.
+
+## Run a Holistic Review
+
+Read [discovery and interviews](references/discovery-and-interviews.md),
+[V-model and traceability](references/v-model-and-traceability.md), and
+[review and compaction](references/review-and-compaction.md).
+
+1. Discover public behavior, source boundaries, tests, CI, and existing documentation
+   read-only.
+2. Interview the developer about intended users, outcomes, compatibility, exclusions,
+   risk, and surprising behavior that evidence cannot classify.
+3. Build a temporary V-model from confirmed goals and compare every layer with code and
+   evidence. Report missing behavior, unintended behavior, weak boundaries, and missing
+   verification without silently normalizing either side.
+4. Improve persistent agent documentation with confirmed current usage, architecture,
+   workflows, and concise unresolved gaps.
+5. Complete the review or agreed corrections, then delete the V-model and its links.
+
+For documentation maintenance without either bounded task, do not reconstruct a
+V-model. Read [repository layout](references/repository-layout.md) and
+[agent context documentation](references/agent-context-documentation.md) as needed.
+
+## Build Durable Documentation
 
 Use [repository layout](references/repository-layout.md) as the topology contract. Start
-from the files under `assets/templates/` selectively; do not copy a template for a
-boundary or record that does not exist. Replace every template token and adapt commands
-to repository evidence.
+from `assets/templates/` selectively and replace every template token.
+Read [agent context documentation](references/agent-context-documentation.md) when
+creating, splitting, or compacting context topics.
 
-Keep each `AGENTS.md` to inherited-scope deltas, local commands and rules, and links that
-say when deeper context should be opened. Put detailed implementation-facing material in
-selectively routed context files. Use stable specification and verification IDs exactly
-as defined by the V-model reference, with objective pass criteria and many-to-many
-reverse links.
+Keep each `AGENTS.md` to inherited-scope deltas, local commands and rules, and links with
+clear open conditions. Put detailed, implementation-facing learning, task, reference,
+and explanation material in `.agents/context/`. Ensure these documents remain useful
+after `.agents/v-model/` is removed.
 
-When intent is uncertain, preserve the uncertainty explicitly and ask the developer only
-about intent or genuine tradeoffs. Do not silently choose code, tests, or old prose as
-the authority. Do not write an unconditional normative claim when repository evidence
-already contains a counterexample.
+When intent is uncertain, record the gap and ask the developer about intent or genuine
+tradeoffs. Do not make an unconditional claim that repository evidence contradicts.
 
 ## Validate
 
-Run the dependency-free, read-only linter from this skill directory:
+Run the dependency-free, read-only linter from this skill directory with an explicit
+V-model state:
 
 ```text
-python3 scripts/lint_repository_docs.py REPOSITORY \
+python3 scripts/lint_repository_docs.py REPOSITORY --v-model active \
+  [--source-root PATH ...] [--json] [--fail-on-warn]
+
+python3 scripts/lint_repository_docs.py REPOSITORY --v-model absent \
   [--source-root PATH ...] [--json] [--fail-on-warn]
 ```
 
-Use repeated `--source-root` options for nonstandard or polyglot layouts. Without an
-option, the linter uses `src` only when it exists. Resolve every integrity error. Treat
-warnings proportionally, but remove avoidable router-size and duplication warnings.
+Use `active` only during initial design, implementation coordination, or holistic
+review. It requires, routes, and validates `.agents/v-model/`. Use `absent` for normal
+repository life and final handoff; it rejects a retained V-model, stale links, and
+confirmed ID references while flagging ambiguous IDs for review. Run `absent` before
+declaring either bounded task complete.
 
-Then review semantics the linter cannot prove:
-
-1. Confirm each normative statement represents intended behavior.
-2. Confirm specifications remain understandable without decision documents.
-3. Try to falsify universal claims with boundary, malformed, and fallback cases.
-4. Confirm every clause in an action’s pass criterion is supported by the cited evidence
-   and that its status is no stronger than that evidence.
-5. Confirm evidence references are durable and statuses are current.
-6. Confirm each context leaf has one dominant need and routers load only relevant detail.
-7. Confirm no source files changed when the task was documentation-only.
+Then confirm semantics the linter cannot prove: statements match developer intent,
+commands work in their documented scope, links load only relevant context, cited tests
+exercise claimed behavior, and unresolved gaps remain visible.
 
 ## Report
 
-Report the selected profile, code roots, files created, moved, or retired, unresolved
-intent or traceability gaps, linter result, semantic review result, developer
-confirmations still needed, and any checks not run.
+Report the workflow, code roots, durable documentation changed, developer confirmations,
+design or implementation gaps, relevant linter results, V-model removal when applicable,
+checks run, and checks not run.

--- a/document-repository-v-model/agents/openai.yaml
+++ b/document-repository-v-model/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Document Repository V-Model"
-  short_description: "Build and audit repository documentation"
-  default_prompt: "Use $document-repository-v-model to structure and validate this repository’s agent-facing documentation."
+  short_description: "Build durable docs and temporary V-models"
+  default_prompt: "Use $document-repository-v-model to design or holistically review this repository and leave durable agent documentation."

--- a/document-repository-v-model/assets/templates/AGENTS-root.md
+++ b/document-repository-v-model/assets/templates/AGENTS-root.md
@@ -9,8 +9,6 @@ guidance for their directory subtrees.
 
 - Open [the repository context index](.agents/index.md) to choose only the topic needed
   for the current task. Do not read `.agents/` recursively.
-- Open [the V-model index](.agents/v-model/index.md) when changing observable behavior,
-  interfaces, acceptance criteria, or verification evidence.
 - Read the closest nested `AGENTS.md` before editing within a code root or subsystem.
 
 ## Code roots
@@ -28,9 +26,9 @@ guidance for their directory subtrees.
 
 - {{REPOSITORY_WIDE_RULE}}
 - Preserve unrelated user changes and follow the repository’s worktree policy.
-- Update canonical specification or context before changing a router that links to it.
+- Update canonical context before changing a router that links to it.
 
 ## Handoff
 
-Report changed behavior and documentation, checks run, unresolved specification or
-evidence gaps, and checks not run.
+Report changed behavior and documentation, checks run, unresolved gaps, and checks not
+run.

--- a/document-repository-v-model/assets/templates/AGENTS-source.md
+++ b/document-repository-v-model/assets/templates/AGENTS-source.md
@@ -9,8 +9,6 @@ This file applies to `{{BOUNDARY_PATH}}/` and supplements inherited repository g
 - Open [{{CONTEXT_TOPIC_NAME}}]({{RELATIVE_AGENTS_PATH}}/context/{{CONTEXT_TOPIC_FILE}})
   when {{OPEN_CONDITION}}.
 - Do not open that topic when {{AVOID_CONDITION}}.
-- Open [the V-model]({{RELATIVE_AGENTS_PATH}}/v-model/index.md) when changing observable
-  behavior or evidence for this boundary.
 
 ## Local commands
 

--- a/document-repository-v-model/assets/templates/context-topic.md
+++ b/document-repository-v-model/assets/templates/context-topic.md
@@ -3,8 +3,8 @@
 - **Context need:** {{CONTEXT_NEED}}
 - **Open when:** {{OPEN_CONDITION}}
 - **Do not open when:** {{AVOID_CONDITION}}
-- **Related specification IDs:** {{SPECIFICATION_IDS}}
 - **Review when:** {{REVIEW_TRIGGER}}
+- **Known gaps:** {{KNOWN_GAPS_OR_NONE}}
 
 ## {{NEED_SPECIFIC_HEADING}}
 

--- a/document-repository-v-model/assets/templates/v-model/index.md
+++ b/document-repository-v-model/assets/templates/v-model/index.md
@@ -1,12 +1,14 @@
 # {{PRODUCT_NAME}} V-Model
 
 - **Profile status:** draft
+- **Task:** {{INITIAL_DESIGN_OR_HOLISTIC_REVIEW}}
 - **Product boundary:** {{PRODUCT_BOUNDARY}}
 - **Acceptance authority:** {{ACCEPTANCE_AUTHORITY}}
 - **Last reviewed:** {{REVIEW_DATE}}
 
-This profile is a repository-specific specification and evidence map. It is not a claim
-of compliance with NASA, FDA, ECSS, or V-Modell XT.
+This is a temporary specification and evidence map for the active task. Delete this
+directory after the initial implementation or holistic review is complete. It is not a
+claim of compliance with NASA, FDA, ECSS, or V-Modell XT.
 
 ## Left-side specification
 

--- a/document-repository-v-model/assets/templates/v-model/verification.md
+++ b/document-repository-v-model/assets/templates/v-model/verification.md
@@ -2,6 +2,8 @@
 
 Update status and durable evidence after execution. Set `passing` only when linked
 evidence exercises every clause in the pass criterion. Do not paste transient run logs.
+Transfer unresolved work to durable context or issues, then delete the V-model when the
+active task is complete.
 
 ## ACC-001 — {{ACCEPTANCE_ACTION_TITLE}}
 

--- a/document-repository-v-model/references/agent-context-documentation.md
+++ b/document-repository-v-model/references/agent-context-documentation.md
@@ -1,53 +1,43 @@
 # Agent Context Documentation
 
-Read this reference only when creating, migrating, splitting, reviewing, or compacting
-`.agents/context/`. Adapt the four needs from [Diátaxis](https://diataxis.fr/) for agent retrieval; do not turn them into four mandatory directories.
-This profile calls them **Guided learning**, **Task playbook**, **Reference**, and **Explanation**.
+Read this reference when creating, splitting, reviewing, or compacting
+`.agents/context/`. Adapt the four needs from [Diátaxis](https://diataxis.fr/) for agent
+retrieval; do not turn them into mandatory directories.
 
 ## Choose one retrieval need
 
-| Need | Diátaxis form | The agent needs to | Include | Exclude |
-| --- | --- | --- | --- | --- |
-| Guided learning | [Tutorial](https://diataxis.fr/tutorials/) | Acquire an unfamiliar repository skill through a safe experience | One supported path, checkpoints, and expected observations | Production mutation, broad alternatives, and background essays |
-| Task playbook | [How-to guide](https://diataxis.fr/how-to-guides/) | Complete a concrete repository task while already competent | Preconditions, goal-directed actions, branches, validation, and recovery | Teaching detours and embedded rationale |
-| Reference | [Reference](https://diataxis.fr/reference/) | Look up exact facts about current machinery | Terse commands, mappings, interfaces, errors, limits, and source anchors | Workflow instruction and argumentative prose |
-| Explanation | [Explanation](https://diataxis.fr/explanation/) | Understand why the implementation has its present shape | Mental models, rationale, alternatives, tradeoffs, and consequences | Step-by-step procedures and duplicated lookup tables |
+| Need | The agent needs to | Include | Exclude |
+| --- | --- | --- | --- |
+| Guided learning | Acquire an unfamiliar repository skill through a safe experience | One supported path, checkpoints, expected observations | Production mutation, broad alternatives, background essays |
+| Task playbook | Complete a concrete task while already competent | Preconditions, actions, branches, validation, recovery | Teaching detours, embedded rationale |
+| Reference | Look up exact facts about current machinery | Commands, mappings, interfaces, errors, limits, source anchors | Workflow instruction, argumentative prose |
+| Explanation | Understand why the implementation has its present shape | Mental models, rationale, alternatives, tradeoffs, consequences | Step-by-step procedures, duplicated lookup tables |
 
-Use the [Diátaxis compass](https://diataxis.fr/compass/): ask whether the agent is acting or understanding, then whether it is acquiring or applying knowledge. Guided learning is action plus acquisition; a Task playbook is action plus application.
-Reference is cognition plus application, and Explanation is cognition plus acquisition.
-
-Give each leaf one dominant need. Split only when a substantial section has a different open condition and would be useful independently. Link incidental facts or rationale instead of duplicating them.
+Use the [Diátaxis compass](https://diataxis.fr/compass/) to distinguish acting from
+understanding and acquiring from applying knowledge. Give each leaf one dominant need.
+Split only when another section has a distinct open condition and is useful by itself.
 
 ## Route for selective loading
 
-Use `.agents/index.md` as the entry point and keep specification routing visually
-separate from working context:
+Use `.agents/index.md` as the persistent entry point:
 
 ```markdown
-## Specification
-
-- [V-model](v-model/index.md) — open when changing observable behavior or evidence.
-
-## Working context
-
 | Context | Need | Open when | Do not open when |
 | --- | --- | --- | --- |
 | [Release flow](context/releases.md) | Task playbook | Preparing or recovering a release | Editing local algorithms |
 ```
 
-Keep context leaves topic-oriented and flat by default. Do not create empty category
-directories. Following [complex-hierarchy guidance](https://diataxis.fr/complex-hierarchies/), add one subindex for a coherent product, domain, or workflow boundary when an index presents more than seven context choices or exceeds its router budget.
-Permit at most one context-subindex hop from `.agents/index.md` to a leaf; a leaf-to-leaf
-link does not make the destination routed. Apply the seven-choice budget to every index;
-split an oversized domain into sibling subindexes rather than nesting another level.
+Keep leaves topic-oriented and flat by default. Add one subindex for a coherent product,
+domain, or workflow boundary when an index presents more than seven choices or exceeds
+its router budget. Permit at most one subindex hop from `.agents/index.md` to a leaf.
 
-A nested `AGENTS.md` should link directly to the relevant leaf when known rather than
-forcing the agent through an index. Add `Scope` only when products or audiences differ;
-preserve physical paths during classification and carry the four-part structure in `Need`.
+A nested `AGENTS.md` should link directly to the relevant leaf when known. During an
+initial design or holistic review, `.agents/index.md` may also link to the temporary
+V-model. Remove that link with the V-model at task completion.
 
 ## Write a context leaf
 
-Start every leaf with this retrieval metadata:
+Start every leaf with retrieval metadata:
 
 ```markdown
 # Topic
@@ -55,46 +45,43 @@ Start every leaf with this retrieval metadata:
 - **Context need:** Guided learning
 - **Open when:** ...
 - **Do not open when:** ...
-- **Related specification IDs:** SYS-001, SUB-002
 - **Review when:** ...
+- **Known gaps:** None
 ```
 
-Use `None — repository-only workflow` only when the topic genuinely has no product-specification relationship. Add anchors and unresolved questions when they help the agent verify freshness or act safely.
+`Known gaps` is optional. Use it for a short, actionable statement of unfinished current
+behavior, including unfinished work transferred from a temporary V-model. Do not retain
+V-model IDs or reproduce the discarded specification.
 
 Shape the body for its need:
 
 - **Guided learning:** State the learning outcome and safe prerequisites. Lead through
-  one reproducible path with small checkpoints and expected observations. End with a
-  completion check and next capability. Link optional alternatives or theory elsewhere.
-- **Task playbook:** State the concrete objective, prerequisites, and constraints. Give
-  actions in goal order, branch where repository state requires it, then cover
-  validation, failure handling, rollback, or handoff. Assume baseline competence.
-- **Reference:** Optimize for scanning with concise tables, lists, and exact current
-  values. Follow the structure of the implementation being described and cite canonical
-  source anchors. Describe facts; do not prescribe a task or argue for a design.
+  one reproducible path with checkpoints and expected observations. End with a
+  completion check and next capability.
+- **Task playbook:** State the objective, prerequisites, and constraints. Give actions in
+  goal order, branch where repository state requires it, then cover validation, failure
+  handling, rollback, or handoff.
+- **Reference:** Optimize for scanning with concise tables, lists, exact values, and
+  canonical source anchors. Describe facts; do not prescribe a task or argue for a
+  design.
 - **Explanation:** Begin with the question or mental model. Explain forces, rationale,
-  alternatives, tradeoffs, history that still affects current work, and implications.
-  Keep the topic bounded and link operational steps or exact facts elsewhere.
+  alternatives, tradeoffs, and implications. Link operational steps and exact facts.
 
-## Preserve the specification boundary
+## Keep context durable
 
-`.agents/v-model/` is the only normative product-specification tree. It must remain
-understandable without context documents. A context Reference describes current
-implementation facts; it does not define required product behavior.
+Describe how to use the project as it exists and how to develop it further. Keep current
+commands, implementation decisions, architecture, source anchors, and rationale here.
+Avoid coupling persistent context to a temporary V-model.
 
-When an implementation decision becomes externally observable, promote only the invariant
-and its objective acceptance meaning into the V-model. Keep the chosen mechanism and
-rationale in context, with links back to the affected specification IDs. If intent is
-unresolved, record the uncertainty instead of promoting observed behavior.
+When a V-model is active, use it to sharpen the docs, but keep the docs understandable
+without it. Before deleting the V-model, transfer only durable knowledge and concise
+unresolved gaps. Avoid copying detailed requirements, trace tables, or temporary review
+status into context.
 
-## Migrate and review proportionally
+## Review proportionally
 
-For new material, create a leaf only for a recurring retrieval need supported by actual
-repository work. During migration, inventory mixed prose, assign a dominant need, retain
-useful anchors, and update inbound links atomically. Do not move or split content merely
-to populate all four needs.
-
+Create a leaf only for a recurring retrieval need supported by real repository work.
 During review, verify that open conditions are distinct, every leaf is routed, body
 shape matches its declared need, and links replace duplicated prose. Merge or split only
-for retrieval, remove stale current state, and keep generated output and run logs outside
-the live context tree.
+for retrieval, remove stale current state, and keep generated output outside the live
+context tree.

--- a/document-repository-v-model/references/discovery-and-interviews.md
+++ b/document-repository-v-model/references/discovery-and-interviews.md
@@ -1,77 +1,77 @@
 # Discovery and Interviews
 
-Use this reference to establish intended behavior for a new project or recover it from
-an existing repository. Keep interviews short and evidence-led.
-
-## Contents
-
-- [New projects](#new-projects)
-- [Existing projects](#existing-projects)
-- [Confidence and baseline rules](#confidence-and-baseline-rules)
+Use this reference to turn a rough new-project prompt into an implementation-ready
+design or to compare an existing codebase with developer-confirmed goals. Keep interviews
+short, concrete, and iterative.
 
 ## New projects
 
-Interview and draft in rounds. After each round, summarize the proposed records,
-uncertainties, and exclusions for developer confirmation.
+Interview before writing code. After each round, summarize proposed requirements,
+uncertainties, and exclusions for confirmation.
 
-### Round 1: repository and intent
+### Round 1: purpose and boundary
 
-Ask only enough to establish:
+Establish:
 
-- Repository and independently released product boundaries.
-- Stakeholders, actors, and who accepts the result.
-- Operational scenarios and intended environments.
-- Outcomes and measurable success.
+- Products, repositories, users, stakeholders, and acceptance authority.
+- Operational scenarios, intended environments, and measurable success.
 - Explicit non-goals and prohibited behavior.
-- Consequence of failure, risk, and required reviewer independence.
-- Legal, platform, compatibility, resource, or delivery constraints.
+- Failure consequences, risk, and required reviewer independence.
+- Legal, platform, compatibility, resource, and delivery constraints.
 
-Draft `STK` outcomes without implementation terminology. Obtain explicit confirmation
-before treating them as the baseline.
+Draft `STK` outcomes without implementation terminology. Do not treat them as confirmed
+until the developer approves them.
 
-### Round 2: observable system behavior
+### Round 2: observable behavior
 
-Ask about capabilities, inputs and outputs, external interfaces, quality attributes,
-error behavior, compatibility ranges, performance budgets, and recovery behavior. Draft
-`SYS` records and `SYSV` intent together. Resolve vague adjectives with examples or
-thresholds.
+Ask about capabilities, inputs, outputs, external interfaces, quality attributes, error
+behavior, compatibility, performance budgets, and recovery. Draft `SYS` requirements
+and `SYSV` actions together. Replace vague adjectives with examples or thresholds.
 
-### Round 3: logical contracts
+### Round 3: independent implementation boundaries
 
-Derive `SUB` responsibilities and boundary semantics, then only the non-obvious `CMP`
-contracts needed for correct implementation and evidence. Ask the developer when a
-choice changes observable behavior or represents a genuine tradeoff. Do not ask them to
-invent details that repository conventions can settle safely.
+Derive `SUB` responsibilities and interface semantics, then the non-obvious `CMP`
+contracts needed for implementation and verification. Make ownership, inputs, outputs,
+state transitions, errors, dependencies, and integration order explicit enough that
+several agents can work on nonoverlapping parts without guessing shared contracts.
 
-### Round 4: implementation context and evidence
+Ask the developer when a choice changes observable behavior or represents a genuine
+tradeoff. Let repository conventions settle low-impact implementation details.
 
-Separate normative specification and router-local rules before capturing architecture,
-packages, tools, workflows, and rationale in `.agents/context/`. Assign each retained
-context leaf exactly one dominant need: `Guided learning`, `Task playbook`, `Reference`,
-or `Explanation`. Create only leaves that answer an evidenced agent retrieval need.
-Map all right-side actions, unresolved issues, environments, and durable evidence
-locations. Add source routers only after actual code roots or meaningful boundaries
-exist.
+### Round 4: working context and evidence
 
-Finish by showing the intended specification, unresolved decisions, and planned evidence
-to the developer for approval.
+Capture architecture choices, packages, tools, commands, workflows, and rationale in
+`.agents/context/`. Assign each context leaf one dominant need: `Guided learning`,
+`Task playbook`, `Reference`, or `Explanation`. Create source routers only after code
+roots or meaningful boundaries exist.
 
-## Existing projects
+Map verification actions, integration checkpoints, unresolved issues, environments, and
+durable evidence locations. Show the complete temporary design and planned work split to
+the developer before implementation begins.
 
-Start with read-only discovery. Parallelize only when applicable instructions permit it.
-Use distinct lanes so conclusions can be reconciled:
+During implementation, use the V-model to coordinate agents and update durable docs as
+the repository takes shape. At completion, reconcile behavior and evidence, transfer
+brief unresolved gaps to persistent context or issues, and delete the V-model.
 
-1. Public docs, examples, manifests, release metadata, and declared compatibility.
+## Existing codebases
+
+Create a temporary V-model only for a holistic goal-versus-implementation review. For
+routine documentation maintenance, inspect the repository directly and keep the V-model
+absent.
+
+Begin a holistic review with read-only discovery. Use distinct lanes when delegation is
+permitted:
+
+1. Public docs, examples, manifests, release metadata, and compatibility promises.
 2. Source entry points, architecture, state and error boundaries, and external APIs.
 3. Tests, fixtures, CI, supported environments, runtime checks, and observed behavior.
-4. Existing `AGENTS.md`, `.agents/`, design documents, issue references, and relevant
-   history.
+4. Existing `AGENTS.md`, `.agents/context/`, design documents, issue references, and
+   relevant history.
 
-Do not change source code during a documentation-only discovery or forward test.
-Do not execute a credentialed, destructive, externally mutating, costly, or
-production-facing test merely to establish documentation evidence. Unless the developer
-has explicitly authorized a suitably isolated and reversible run, record the action as
-planned and specify the fixture, safeguards, and acceptance environment it needs.
+Do not change source code during discovery. Do not run credentialed, destructive,
+externally mutating, costly, or production-facing tests without explicit authorization
+and suitable isolation. Record unsafe actions as planned evidence with their fixtures,
+safeguards, and environment.
 
 ### Maintain an evidence ledger
 
@@ -79,81 +79,54 @@ For each candidate claim, record:
 
 | Field | Meaning |
 | --- | --- |
-| Candidate claim | The smallest behavior, intent, decision, or conflict being assessed |
+| Candidate claim | Smallest behavior, goal, decision, or conflict being assessed |
 | Evidence | Exact file, symbol, test, commit, release, or developer statement |
 | Evidence kind | Documentation, code, test, runtime, history, or interview |
 | Confidence | High, medium, or low, with a short reason |
 | Conflict | Contrary evidence or missing perspective |
-| Proposed class | Intended specification, accepted decision, defect/spec gap, obsolete behavior, or unresolved |
+| Proposed class | Intended goal, accepted decision, design defect, missing implementation, obsolete behavior, or unresolved |
 
-Code and tests are evidence of current behavior. They are not automatic proof that the
-behavior is desired. Public documentation may describe intent but still be stale. A
-developer statement can establish intent, but compare it with shipped compatibility and
-stakeholder commitments before removing behavior.
-Do not equate an export list with a stable public contract: reconcile exports, explicit
-stability/private markers, release notes, supported examples, and actual downstream use.
+Code and tests show current behavior; they do not establish that it is desired. Public
+documentation can describe intent but may be stale. Compare developer statements with
+shipped compatibility and stakeholder commitments.
 
-For CI evidence, trace each matrix value, environment variable, feature flag, tag, and
-filter through the test entry point to the selected cases. Similar job and selector
-names are not evidence that the intended shard actually runs.
-
-Before turning a candidate into a normative statement, try to falsify it. Probe empty,
-malformed, boundary, fallback, negative, and repeated-call cases in proportion to risk.
-Exercise each public entry point, default, override, and diagnostic path that can reach
-the behavior.
-Treat words such as “all,” “every,” “any,” “deterministic,” and “supported” as prompts
-for counterexamples. If known behavior contradicts a proposed universal claim, keep the
-conflict unresolved or narrow the record; draft status does not make an internally
-inconsistent statement acceptable.
-
-For filesystem deletion or other destructive state changes, also probe canonicalized
-and traversal paths, symlinks or aliases, pre-existing and stale success markers,
-partial prior runs, zero/negative/nonnumeric/overflow limits, and repeated invocations.
-State containment relative to resolved targets, not merely a configured path string.
-Treat “fail open,” “continue,” and “recover” as caller-control-flow claims unless
-evidence separately establishes remote atomicity, rollback, idempotent retry, and the
-resulting partial state.
+Trace CI matrix values, flags, tags, and filters through the actual test entry point.
+Before accepting a universal claim, probe empty, malformed, boundary, fallback,
+negative, and repeated-call cases in proportion to risk. For destructive behavior, also
+check canonical paths, traversal, aliases, stale success markers, partial prior runs,
+invalid limits, and retries.
 
 ### Interview only the gaps
 
-After discovery, ask compact questions about matters inspection cannot establish:
+Ask the developer what inspection cannot establish:
 
-- Which users and scenarios are authoritative?
-- Is a surprising behavior intentional, tolerated debt, or a defect?
-- Which compatibility promises and exclusions must remain?
-- Which conflicts should be resolved now and which remain explicit?
-- What failure consequences or acceptance thresholds drive assurance?
+- Which users, scenarios, outcomes, and exclusions are authoritative?
+- Is surprising behavior intentional, tolerated debt, a design defect, or missing work?
+- Which compatibility promises must remain?
+- Which conflicts should be resolved now?
+- What failure consequences and acceptance thresholds drive assurance?
 
-Show the exact competing evidence with each question. Avoid asking for facts already
-available in the repository.
+Show the competing evidence with each question. Convert confirmed goals into the
+temporary V-model, then compare them systematically with implementation and evidence.
 
-### Classify before moving prose
+### Classify review findings
 
-Assign each observed claim to one class:
+- **Matched:** implementation and evidence satisfy confirmed intent.
+- **Design defect:** architecture or boundary choices obstruct a confirmed goal.
+- **Missing implementation:** confirmed behavior is absent or incomplete.
+- **Unintended behavior:** implemented behavior conflicts with a confirmed goal.
+- **Verification gap:** a claim lacks objective or durable evidence.
+- **Accepted decision:** current implementation choice and rationale belong in context.
+- **Unresolved:** record the question, evidence, owner, and review trigger.
 
-- **Intended specification:** confirmed normative behavior; move or write it in the
-  V-model with objective evidence.
-- **Accepted implementation decision:** current “how” and rationale; keep it in a context
-  topic linked to the fulfilled specification.
-- **Defect or specification gap:** code and intended behavior differ; keep the mismatch
-  explicit and do not rewrite either side to hide it.
-- **Obsolete behavior:** no longer intended; remove current-state guidance and retain a
-  short retirement note only when compatibility requires one.
-- **Unresolved:** evidence conflicts or intent is unavailable; record the question,
-  evidence, owner, and review trigger.
+Complete the agreed review output or corrections, update durable docs, reduce unfinished
+items to concise current gaps, then delete the V-model and run the linter in `absent`
+mode.
 
-Preserve useful existing open/avoid criteria, source anchors, test anchors, commands, and
-local rules. Replace duplicated normative prose with canonical V-model links. After
-separating specification and router-local material, classify each retained context leaf
-as `Guided learning`, `Task playbook`, `Reference`, or `Explanation`; do not create
-empty category scaffolding.
+## Confidence rules
 
-## Confidence and baseline rules
-
-- Baseline only developer-confirmed or otherwise authoritative intended behavior.
-- Leave inferred records in `draft` status and identify their evidence.
-- Do not turn “the test currently passes” into a stakeholder outcome.
-- Do not infer that a cited test covers clauses or edge cases it never exercises.
-- Do not turn one example into a general compatibility guarantee.
-- Do not silently choose between documentation and code when they conflict.
-- Record what was not inspected and why.
+- Treat only developer-confirmed or otherwise authoritative goals as normative.
+- Do not turn a passing test into a stakeholder outcome.
+- Do not claim that evidence covers clauses or edge cases it never exercises.
+- Do not generalize one example into a compatibility guarantee.
+- Keep conflicts visible and record what was not inspected.

--- a/document-repository-v-model/references/repository-layout.md
+++ b/document-repository-v-model/references/repository-layout.md
@@ -1,28 +1,22 @@
 # Repository Layout
 
-Use this reference when creating or migrating the documentation tree, declaring code
-roots, or deciding where nested routers and topic files belong.
+Use this reference when creating or reorganizing agent-facing documentation, declaring
+code roots, or deciding where nested routers and context topics belong.
 
 ## Contents
 
-- [Why this layout](#why-this-layout)
-- [Default topology](#default-topology)
+- [Persistent topology](#persistent-topology)
+- [Temporary V-model](#temporary-v-model)
 - [Declare code roots](#declare-code-roots)
 - [Keep routers small](#keep-routers-small)
 - [Route repository context](#route-repository-context)
-- [Keep specification separate](#keep-specification-separate)
 - [Use the templates selectively](#use-the-templates-selectively)
 - [Exclude transient material](#exclude-transient-material)
 
-## Why this layout
+## Persistent topology
 
-[OpenAI’s harness-engineering guidance](https://openai.com/index/harness-engineering/)
-describes a short `AGENTS.md` as a map into structured repository knowledge, with
-progressive disclosure and mechanical checks for cross-links and drift. Apply that
-pattern here with `.agents/` as the selectively loaded knowledge tree. The exact
-directory name is this profile’s convention, not an OpenAI product requirement.
-
-## Default topology
+Use a short `AGENTS.md` as a map into selectively loaded repository knowledge. Keep the
+normal repository state independent of any V-model:
 
 ```text
 AGENTS.md
@@ -30,29 +24,57 @@ AGENTS.md
 <meaningful-subsystem>/AGENTS.md
 .agents/
 ├── index.md
-├── context/
-│   └── <topic>.md
-└── v-model/
-    ├── index.md
-    ├── 01-stakeholder-outcomes.md
-    ├── 02-system-requirements.md
-    ├── 03-subsystem-contracts.md
-    ├── 04-component-contracts.md
-    └── verification.md
+└── context/
+    └── <topic>.md
 ```
 
-Treat this as a default, not a demand for empty files. Create the complete V-model
-profile, but add context topics and nested routers only for information and boundaries
-that exist.
+This applies the progressive-disclosure pattern described by
+[OpenAI's harness-engineering guidance](https://openai.com/index/harness-engineering/).
+The `.agents/` directory is this skill's convention, not an OpenAI requirement. Create
+only context topics and nested routers supported by real retrieval needs and boundaries.
+
+## Temporary V-model
+
+Add `.agents/v-model/` only during an initial design before code or a holistic codebase
+review:
+
+```text
+.agents/v-model/
+├── index.md
+├── 01-stakeholder-outcomes.md
+├── 02-system-requirements.md
+├── 03-subsystem-contracts.md
+├── 04-component-contracts.md
+└── verification.md
+```
+
+While it is active, link it from `.agents/index.md` with a clear temporary open
+condition. A task branch may carry it for multi-agent coordination. Before completing
+the implementation or review:
+
+1. Transfer current usage, architecture, commands, and development knowledge into
+   durable context.
+2. Rewrite unfinished requirements as brief, actionable gaps in the relevant context
+   topic or issue tracker; do not retain orphaned V-model IDs.
+3. Remove links to the V-model, then delete `.agents/v-model/`.
+4. Run the linter with `--v-model absent`.
+
+Do not recreate this tree for routine changes or maintain it as a parallel description
+of an established, reviewed codebase.
+
+For a large active profile, replace a layer file with a same-named directory containing
+`index.md` and topic shards. For independently released products, place one complete
+profile per product under `.agents/v-model/` and route to them from its index. Keep IDs
+unique repository-wide.
 
 ## Declare code roots
 
 - Require `src/AGENTS.md` whenever `src/` exists.
 - For a nonstandard or polyglot repository, list every actual code root in the root
   router and create an equivalent router in each one. Examples include `app/`, `gui/`,
-  `packages/`, `cmd/`, or a repository root that contains executable code directly.
+  `packages/`, `cmd/`, or a repository root containing executable code directly.
 - Pass the same roots to the linter with repeated `--source-root` options. Do not invent
-  a `src/` directory just to satisfy the profile.
+  `src/` merely to satisfy the profile.
 - Treat an independently built frontend, backend, library, plugin, or service as a
   likely code root when its manifest and workflow are distinct.
 
@@ -61,84 +83,38 @@ that exist.
 Every `AGENTS.md` contains only:
 
 1. Its scope and inherited-scope deltas.
-2. Commands that are valid in that scope.
+2. Commands valid in that scope.
 3. Local rules or invariants that directly guide work.
-4. Links to canonical topic or specification documents, with an explicit “open when”
-   condition.
+4. Links to canonical context with an explicit open condition.
 
-Do not restate architecture, requirement records, rationale, history, or long testing
-guides. Do not ask an agent to read `.agents/` recursively. A nested router overrides or
-adds to inherited guidance; it does not copy the parent.
-
-Add a nested router only when a directory is a meaningful subsystem, module, ownership
-boundary, or distinct development workflow. File count alone is not a boundary. A stable
-interface, separate release unit, different toolchain, or different validation command
-is stronger evidence.
+Do not restate architecture, rationale, history, or long testing guides. Do not ask an
+agent to read `.agents/` recursively. Add a nested router only for a meaningful
+subsystem, ownership boundary, release unit, toolchain, or development workflow.
 
 ## Route repository context
 
-Make `.agents/index.md` the repository-wide router. Link directly to context leaves when
-the relevant leaf is known, and give every link explicit “open when” and “do not open
-when” conditions. Keep names aligned to an agent's retrieval task rather than
-organizational history.
+Make `.agents/index.md` the repository-wide router. Link directly to a context leaf when
+known, with explicit "open when" and "do not open when" conditions. Name topics for an
+agent's retrieval task rather than organizational history.
 
-When creating, classifying, splitting, or reviewing context, read
-[agent context documentation](agent-context-documentation.md). It defines four
-agent-facing retrieval needs and the adaptive rules for adding subindexes without
-forcing four category directories. Keep the tree flat until a real product, domain, or
-workflow boundary makes another routing hop useful. Never ask an agent to preload a
+Read [agent context documentation](agent-context-documentation.md) when creating,
+classifying, splitting, or reviewing context. Keep the tree flat until a real product,
+domain, or workflow boundary requires one additional routing hop. Never preload a
 category or recursively read `.agents/context/`.
-
-## Keep specification separate
-
-`.agents/v-model/` is the only normative product-specification tree in this profile.
-Keep it understandable without opening `.agents/context/`. Section-level context links
-may supply essential background, but must not carry normative meaning.
-
-For a large layer, replace its canonical Markdown file with a same-named directory:
-
-```text
-.agents/v-model/03-subsystem-contracts/
-├── index.md
-├── storage.md
-└── transport.md
-```
-
-The directory index routes to shards. Keep record IDs unique repository-wide. Apply the
-same file-or-directory form to `verification` when verification records need sharding.
-
-For independently released products in one repository, make `.agents/v-model/index.md`
-route to one complete profile per product:
-
-```text
-.agents/v-model/
-├── index.md
-├── product-a/
-│   ├── index.md
-│   └── <all four layers plus verification>
-└── product-b/
-    ├── index.md
-    └── <all four layers plus verification>
-```
-
-Do not combine products merely because they share a repository. Do not split one product
-merely because it uses several languages.
 
 ## Use the templates selectively
 
-- `assets/templates/AGENTS-root.md`: root router.
-- `assets/templates/AGENTS-source.md`: code-root or meaningful-boundary router.
-- `assets/templates/context-topic.md`: one context leaf, shaped for its retrieval need.
-- `assets/templates/v-model/`: a complete small single-product profile.
+- `assets/templates/AGENTS-root.md`: persistent root router.
+- `assets/templates/AGENTS-source.md`: persistent code-root or boundary router.
+- `assets/templates/context-topic.md`: persistent context leaf.
+- `assets/templates/v-model/`: temporary small single-product profile.
 
 Copy, rename, and fill only what the repository needs. Replace all `{{TOKEN}}` values.
-Preserve existing useful prose by moving it to the correct canonical home and replacing
-the old copy with a link.
+Move useful existing prose to its canonical home and replace duplicate copies with
+links.
 
 ## Exclude transient material
 
-Keep generated reports, large CSV/JSON exports, images, database files, recordings, and
-run logs outside the live `.agents/` tree. Link to a durable evidence location instead.
-Retain current status and durable references in `verification.md`, not copied console
-output. Rely on Git history for obsolete prose unless a short retirement record is
-needed for compatibility.
+Keep generated reports, large data exports, images, database files, recordings, and run
+logs outside `.agents/`. Link to durable evidence instead. Rely on Git history for
+obsolete prose unless compatibility work needs a short retirement note.

--- a/document-repository-v-model/references/review-and-compaction.md
+++ b/document-repository-v-model/references/review-and-compaction.md
@@ -1,136 +1,104 @@
 # Review and Compaction
 
-Use this reference for scheduled audits, release readiness, drift checks, and efforts to
-reduce agent context cost without weakening meaning.
+Use this reference for a holistic goal-versus-code review or for reducing persistent
+agent context without weakening current guidance.
 
-## Contents
+## Choose the review scope
 
-- [Review triggers](#review-triggers)
-- [Independent review streams](#independent-review-streams)
-- [Reconciliation order](#reconciliation-order)
-- [Compaction rules](#compaction-rules)
-- [Warning budgets](#warning-budgets)
-- [Semantic consistency checklist](#semantic-consistency-checklist)
-- [Idempotence check](#idempotence-check)
+- **Holistic review:** Interview the developer, create a temporary V-model, compare the
+  whole codebase with confirmed goals, update durable docs, and delete the V-model at
+  completion.
+- **Documentation review:** Check routers, context, commands, links, duplication, and
+  drift with the V-model absent. Do not reconstruct one.
 
-## Review triggers
-
-Review after changes to observable behavior, public interfaces, architecture, code roots,
-ownership boundaries, supported environments, or test strategy. Also review before a
-major release and at least quarterly for an actively maintained repository.
-
-Run the linter first to expose mechanical failures, but do not treat a clean linter result
-as semantic approval.
+Review persistent docs after changes to architecture, code roots, ownership boundaries,
+supported environments, commands, or test strategy. Run the linter first, but do not
+treat a clean result as semantic approval.
 
 ## Independent review streams
 
 When scale and permissions allow, separate these passes:
 
-1. **Router and link integrity:** scopes, code roots, inheritance deltas, open/avoid
-   routing, local links, and meaningful boundaries.
-2. **V-model and traceability:** record quality, parent layers, objective criteria,
-   right-side coverage, methods, statuses, evidence, and nonconformance.
-3. **Code/test versus context:** current implementation, tests, CI, commands, anchors,
-   compatibility, decision-document drift, and context-need fit.
-4. **Duplication and context cost:** repeated prose, oversized routers, overlapping
-   or mixed-purpose topics, stale logs, unnecessary routing hops, and material that
-   should not load by default.
+1. **Router and link integrity:** scopes, code roots, inheritance deltas, open conditions,
+   local links, and meaningful boundaries.
+2. **Code/test versus context:** implementation, tests, CI, commands, anchors,
+   compatibility, rationale, and context-need fit.
+3. **Duplication and context cost:** repeated prose, oversized routers, mixed-purpose
+   topics, stale logs, unnecessary hops, and default-loaded detail.
+4. **Intent and coverage:** only for a holistic review; compare temporary V-model records
+   with source and evidence, including counterexamples and nonconformance.
 
 Use an independent reviewer for high-risk conclusions. Reconcile findings centrally;
-reviewers identify evidence and impact but do not each rewrite the canonical files.
+reviewers return evidence and impact rather than competing rewrites.
 
 ## Reconciliation order
 
 1. Resolve or explicitly record conflicts about intent.
-2. Update canonical V-model or context content.
-3. Repair traceability and durable evidence references.
-4. Update indexes and detailed topic routing.
-5. Shorten root and nested routers last.
-6. Re-run mechanical and semantic review after every move or deletion.
-
-This order prevents a concise router from pointing to stale or missing detail.
+2. Update durable context and commands.
+3. Repair links and indexes.
+4. Shorten root and nested routers last.
+5. Re-run mechanical and semantic review after moves or deletions.
+6. For a holistic review, transfer unresolved work to concise current gaps, remove
+   V-model links, delete the V-model, and lint with `--v-model absent`.
 
 ## Compaction rules
 
 - Replace duplicated prose with one canonical statement and contextual links.
 - Keep a rule in the closest router where it applies; remove inherited restatements.
-- Separate normative specification and router-local rules before classifying context.
-- Assign every context leaf exactly one dominant need: `Guided learning`,
-  `Task playbook`, `Reference`, or `Explanation`.
-- Split a mixed-purpose context document only when substantial sections serve distinct
-  retrieval needs; otherwise keep its dominant need and link to supporting context.
-- Do not add empty need categories, and do not move a leaf merely to fill a taxonomy.
-- Merge small topics only when agents always need them together and they share a
-  dominant need.
+- Give every context leaf one dominant need: `Guided learning`, `Task playbook`,
+  `Reference`, or `Explanation`.
+- Split a mixed-purpose document only when substantial sections have distinct open
+  conditions and are independently useful.
+- Merge small topics only when agents always need them together.
 - Remove obsolete current-state material and rely on Git history.
-- Retain a brief retirement/replacement record only when compatibility or migration
-  work needs it.
-- Never shorten a requirement by weakening actors, conditions, thresholds, exclusions,
-  or pass/fail meaning.
-- Prune historical run logs from verification records. Retain current status, durable
-  evidence locations, and unresolved nonconformance.
+- Retain a brief retirement note only when compatibility or migration work needs it.
 - Keep generated reports and bulky artifacts outside `.agents/`.
+- Do not copy a temporary V-model into context. Preserve only useful current knowledge
+  and brief actionable gaps.
 
-Before deleting or moving a document, find all inbound links and specification IDs.
-Repair those references in the same change. Verify that a proposed merge does not combine
-normative specification with implementation rationale.
+Before deleting or moving a document, find inbound links and repair them in the same
+change.
 
 ## Warning budgets
 
-The linter warns, rather than fails, at these default budgets:
+The linter warns at these defaults:
 
 | Document | Lines | Words | Records |
 | --- | ---: | ---: | ---: |
 | Root `AGENTS.md` | 100 | 700 | — |
 | Nested `AGENTS.md` | 40 | 250 | — |
 | Any `.agents/**/index.md` | 100 | 600 | — |
-| Context detail or V-model shard | 200 | 1,200 | 40 |
+| Context detail or active V-model shard | 200 | 1,200 | 40 |
 
-Treat a warning as a retrieval-cost signal. A justified large shard may remain, but an
-oversized router is usually the wrong place for detail. Use `--fail-on-warn` for a strict
-release gate after known proportional exceptions have been resolved.
+Treat a warning as a retrieval-cost signal. A justified large context leaf may remain,
+but an oversized router is usually the wrong place for detail. Use `--fail-on-warn` for
+a strict gate after proportional exceptions have been resolved.
 
-The linter also warns about invalid context metadata, unreachable context leaves,
-oversized or over-nested context routing, unjustified missing specification links,
-duplicated prose, bulky artifacts, likely source boundaries without routers, and
-placeholders in baselined profiles.
+The linter also checks context metadata, reachability, routing depth, duplicate prose,
+bulky artifacts, likely source boundaries without routers, and placeholders in active
+baselined profiles.
 
-## Semantic consistency checklist
+## Semantic checklist
 
-- Does each `AGENTS.md` say what to open and when, without preloading everything?
-- Starting from a concrete task, can an agent reach the relevant context leaf without
-  browsing or loading unrelated context?
-- Does each context leaf consistently serve its declared dominant need:
-  `Guided learning`, `Task playbook`, `Reference`, or `Explanation`?
-- Do prose claims about child routers match routers that actually exist?
-- Are commands executable from the scope where they are documented?
-- Does each normative record express intended behavior rather than observed accidents?
-- Has each universal or deterministic claim survived boundary and counterexample review?
-- For destructive behavior, were path traversal, symlinks, stale state, partial prior
-  runs, invalid limits, and repeated invocations checked?
-- Do fail-open or recovery claims distinguish caller continuation from partial side
-  effects, rollback, and retry behavior?
-- Can the V-model be understood without decision documents?
-- Do parent and verification links represent real semantic coverage?
-- Does every claimed consumer of a shared schema or registry actually load or derive
-  from it, rather than maintain an independent copy?
-- Does each criterion permit an objective decision, and does cited evidence exercise
-  every clause, direction, entry point, and edge case it claims?
-- Are fixtures discriminating, or could a swapped field, direction, branch, or order
-  produce the same expected result?
-- Do CI matrix values, environment variables, tags, and filters actually select the
-  cited tests end to end?
-- Does each `passing` status still match durable evidence?
-- Are current source paths, workflow names, and tool choices kept out of normative
-  compatibility or interface outcomes?
-- Are failure paths, external interfaces, performance, security, and compatibility
-  covered in proportion to risk?
-- Do context decisions still match source and test anchors?
-- Are unresolved mismatches visible rather than normalized away?
+- Does each `AGENTS.md` say what to open and when?
+- Can an agent reach the relevant context without loading unrelated material?
+- Does each context leaf serve its declared need and remain useful without a V-model?
+- Do documented commands work from their stated scope?
+- Do prose claims about source paths, workflows, and child routers match the repository?
+- Are current architecture decisions and rationale kept in context rather than routers?
+- Are unresolved implementation gaps brief, actionable, and current?
+- For a holistic review, does each normative statement reflect confirmed intent rather
+  than observed behavior?
+- Have universal claims survived boundary and counterexample checks?
+- Does cited evidence exercise every clause, direction, entry point, and edge case it
+  claims?
+- Do CI values, tags, flags, and filters select the cited tests end to end?
+- Are design defects, missing behavior, unintended behavior, and verification gaps
+  visible rather than normalized away?
+- At final handoff, is `.agents/v-model/` absent with no stale links or IDs?
 
 ## Idempotence check
 
-After a migration or broad update, run a second documentation pass from the resulting
-repository state. It should make no unnecessary edits. A nonempty second diff indicates
-unstable ordering, duplicated authority, unresolved template tokens, or unclear routing.
-Fix the cause instead of accepting churn.
+After a broad documentation update, run a second pass from the resulting repository
+state. It should make no unnecessary edits. A nonempty second diff indicates unstable
+ordering, duplicated authority, unresolved template tokens, or unclear routing.

--- a/document-repository-v-model/references/subagent-playbooks.md
+++ b/document-repository-v-model/references/subagent-playbooks.md
@@ -1,131 +1,88 @@
 # Subagent Playbooks
 
-Use this reference only when the environment and applicable instructions permit
-delegation. Scale independence and specialist effort to risk; keep one coordinator
-responsible for intent, reconciliation, and final edits.
+Use this reference only when the environment and repository instructions permit
+delegation. Keep one coordinator responsible for developer intent, shared contracts,
+integration, durable docs, and V-model deletion.
 
-## Contents
+## Isolation
 
-- [Isolation rules](#isolation-rules)
-- [Risk-scaled staffing](#risk-scaled-staffing)
-- [Standard V-layer cohorts](#standard-v-layer-cohorts)
-- [Existing-repository discovery](#existing-repository-discovery)
-- [Consistency review](#consistency-review)
-- [Clean-room forward testing](#clean-room-forward-testing)
+- Give each agent a concrete, bounded lane with explicit inputs, outputs, dependencies,
+  and verification.
+- Provide the skill path, repository path, pinned commit, and a normal user-style task.
+- Use a separate worktree or disposable clone per writing agent. Never share a worktree.
+- For discovery and evaluation, prohibit source changes and pushes.
+- Require exact file, symbol, and test anchors with confidence and conflicts.
+- Keep one concurrency slot for the coordinator.
 
-## Isolation rules
+## Initial implementation swarm
 
-- Give each operator a concrete, bounded, primarily read-only lane.
-- Provide the skill path, repository path, exact pinned commit, and a normal user-style
-  request. Do not reveal expected answers, suspected defects, or another reviewer’s
-  conclusions.
-- Use a separate disposable clone or worktree per writing agent. Never let agents edit
-  the same worktree.
-- For discovery and evaluation, prohibit source-code changes and pushes.
-- Ask for evidence with exact file/symbol/test anchors, confidence, conflicts, and
-  unresolved questions.
-- Keep one slot for the coordinator when concurrency is limited.
+Do not delegate implementation until the developer has confirmed stakeholder outcomes,
+observable behavior, subsystem boundaries, shared interfaces, error semantics, and
+acceptance criteria.
 
-If subagents are unavailable, perform the same lanes sequentially and use a fresh context
-for the independent review when possible.
+Split work along stable `SUB` boundaries rather than arbitrary file counts. For each
+agent, provide:
 
-## Risk-scaled staffing
+1. Owned requirements and component contracts.
+2. Inputs, outputs, state transitions, errors, and prohibited changes.
+3. Dependencies and integration order.
+4. Required tests or other evidence and objective pass criteria.
+5. The persistent context topics and local router that apply.
 
-| Risk/scale | Suggested approach |
-| --- | --- |
-| Tiny, low-risk repository | One operator plus a short independent trace/size review |
-| Ordinary repository | Coordinator plus documentation/source and test/trace operators |
-| Large brownfield or polyglot repository | Coordinator plus code/spec archaeologist, verification mapper, and boundary/router reviewer |
-| High assurance or destructive behavior | Add domain, security/safety, failure-injection, environment, and independent trace specialists as relevant |
+Assign separate integration work when several agents touch one contract. Have the
+coordinator reconcile interface changes before dependents proceed. Update durable
+context as code, commands, and architecture become concrete.
 
-Do not add specialists merely to fill slots. Add them when a distinct evidence domain or
-independence requirement exists.
+After integration, independently inspect trace coverage and try boundary cases. Transfer
+unfinished items to concise context gaps or issues, remove V-model links and IDs, delete
+`.agents/v-model/`, and lint in `absent` mode.
 
-## Standard V-layer cohorts
+## Holistic codebase review
 
-| Layer | Cohort |
-| --- | --- |
-| `STK` / `ACC` | Domain or stakeholder proxy; acceptance-scenario designer; independent trace reviewer |
-| `SYS` / `SYSV` | Requirements analyst; black-box verification designer/executor; relevant performance, security, or compatibility specialist; reviewer |
-| `SUB` / `INTV` | One contract investigator per important boundary; dependency/environment or failure-injection specialist; architecture/trace integrator |
-| `CMP` / `UNITV` | Component/unit-test investigator; static-analysis or code-inspection investigator; orphan/coverage reviewer |
+Use nonoverlapping discovery lanes:
 
-A specialist may cover several roles in a small repository. Preserve independence for the
-final trace review when failure impact warrants it.
+- **Public contract:** docs, examples, manifests, releases, compatibility promises.
+- **Code architecture:** entry points, state and error boundaries, APIs, subsystems.
+- **Verification:** tests, CI, fixtures, environments, skips, evidence durability.
+- **Agent context:** router scope, selective loading, commands, duplication, anchors.
 
-## Existing-repository discovery
+The coordinator merges evidence, then interviews the developer only about intent that
+inspection cannot establish. Build the temporary V-model from confirmed goals.
 
-Give operators nonoverlapping questions:
+Assign independent comparisons for stakeholder outcomes, system behavior, subsystem
+contracts, component invariants, and verification. Every finding must include:
 
-- **Public contract operator:** Inspect public docs, examples, manifests, release metadata,
-  and declared compatibility. Return candidate observable claims and contradictions.
-- **Code archaeologist:** Inspect entry points, data/state/error boundaries, public APIs,
-  and major subsystems. Return observed behavior and architecture decisions separately.
-- **Verification mapper:** Inspect tests, CI, fixtures, supported environments, skips,
-  expected failures, and evidence durability. Return coverage and orphan candidates.
-- **Agent-context reviewer:** Inspect existing routers and context for scope, duplication,
-  open/avoid criteria, anchors, staleness, and likely migration targets. Separate
-  specification and router-local rules, then classify each retained leaf as
-  `Guided learning`, `Task playbook`, `Reference`, or `Explanation`.
+1. Classification: matched, design defect, missing implementation, unintended behavior,
+   verification gap, accepted decision, or unresolved.
+2. Affected goal, code, and evidence anchors.
+3. Impact and confidence.
+4. Smallest safe correction or follow-up.
+5. Whether developer intent is still required.
 
-The coordinator merges evidence into one ledger, asks the developer only unresolved
-intent questions, and classifies claims before anyone writes a baseline.
+For sampled passing actions, compare every phrase in the procedure and criterion with
+the cited evidence. Search for counterexamples to universal claims. Mechanical reverse
+links are not semantic coverage.
 
-## Consistency review
+The coordinator deduplicates findings, applies agreed corrections, improves durable
+docs, and deletes the V-model at review completion.
 
-Assign independent passes for router/link integrity, V-model/traceability, source/test
-drift, and duplication/token cost. Require each finding to include:
+## Documentation review
 
-1. Severity and affected IDs/files.
-2. Exact evidence.
-3. Why it is inconsistent or costly.
-4. Smallest safe correction.
-5. Whether developer intent is required.
+Keep the V-model absent. Assign independent passes for router/link integrity,
+source/test drift, context retrieval quality, and duplication. Start from representative
+repository tasks and follow only the links an agent is told to open. Report missing
+routes, unnecessary hops, unrelated material, stale commands, and mixed context needs.
 
-For every `passing` action sampled, open the cited evidence and compare its exercised
-cases with each phrase in the procedure and pass criterion. Sample universal normative
-claims with at least one boundary or counterexample search. Mechanical reverse links are
-not semantic coverage.
+## Forward-test this skill
 
-For the context-cost pass, start with representative repository tasks and follow only
-the links an agent would be told to open. Report missing routes, unnecessary hops,
-indexes presenting more than seven choices, unrelated documents loaded, and mixed or
-incorrect context needs. Do not recursively preload `.agents/` to perform this review.
+Skill maintainers should use disposable clones pinned to exact commits. Test at least:
 
-Have the coordinator deduplicate findings and apply changes in the reconciliation order
-from `review-and-compaction.md`.
+- A rough new-project prompt that must become a precise, parallelizable design before
+  any code is written.
+- A brownfield codebase whose implementation conflicts with developer-stated goals.
+- An established repository receiving routine docs maintenance with no V-model.
+- Final cleanup of both bounded workflows, including successful `--v-model absent`
+  linting.
 
-## Clean-room forward testing
-
-Skill maintainers should forward-test with disposable clones pinned to exact commits.
-Use three small operators concurrently with one coordinator; for a large case use an
-operator, code/spec archaeologist, and verification mapper, then reuse them as independent
-cross-reviewers.
-
-Core release cases:
-
-- `QuantumSavory.jl`: preserve selective router/context strengths while detecting drift
-  and separating specification from decisions.
-- `PBCCompiler.jl`: migrate a monolithic `AGENTS.md`.
-- `TermInterface.jl`: verify proportional output for a tiny library.
-- `QuantumClifford.jl`: exercise brownfield discovery and subsystem traceability.
-- `WebQuantumSavory`: exercise polyglot roots and cross-stack contracts.
-
-Rotate `QuantumInterface.jl` for externally consumed contracts,
-`julia-buildkite-plugin` for no conventional `src/`, and `AnythingLLMDocs.jl` for
-external-service and safety-aware acceptance planning. Never execute a live destructive
-test merely to evaluate documentation generation.
-
-Require:
-
-- No hard linter errors or avoidable router warnings.
-- Complete bidirectional traceability.
-- No implementation decisions duplicated into specification.
-- No observed behavior promoted to intent without evidence or confirmation.
-- Selective context loading and no source-code changes.
-- An empty unnecessary second-pass diff.
-- Independent approval for correctness, proportionality, interview quality, and context
-  efficiency.
-
-Keep prompts, raw diffs, linter JSON, and scores outside the shipped skill. Retain them
-only until findings are incorporated, then remove clones and temporary artifacts.
+Keep prompts, raw diffs, linter output, and scores outside the shipped skill. Retain them
+only until findings are incorporated, then remove temporary artifacts.

--- a/document-repository-v-model/references/v-model-and-traceability.md
+++ b/document-repository-v-model/references/v-model-and-traceability.md
@@ -1,71 +1,59 @@
 # V-Model and Traceability
 
-Use this reference whenever writing, changing, or reviewing normative specification and
-verification records.
+Use this reference only while designing a new project before code or conducting a
+holistic review of an existing codebase.
 
 ## Contents
 
-- [Profile and source basis](#profile-and-source-basis)
-- [Incremental V-model](#incremental-v-model)
+- [Purpose and lifetime](#purpose-and-lifetime)
 - [Four specification layers](#four-specification-layers)
-- [Specification record format](#specification-record-format)
-- [Verification action format](#verification-action-format)
-- [Traceability rules](#traceability-rules)
+- [Specification records](#specification-records)
+- [Verification actions](#verification-actions)
+- [Traceability](#traceability)
 - [Specification versus decisions](#specification-versus-decisions)
 - [Risk tailoring](#risk-tailoring)
+- [Close the V-model](#close-the-v-model)
 
-## Profile and source basis
+## Purpose and lifetime
 
-This is a repository-neutral V-profile. It borrows useful distinctions and traceability
-practices; it does not establish compliance with NASA, FDA, ECSS, V-Modell XT, or any
-regulated lifecycle.
+Use the V-model for exactly two bounded tasks:
 
-- [NASA Systems Engineering Handbook §2.4](https://www.nasa.gov/reference/2-4-distinctions-between-product-verification-and-product-validation/)
-  distinguishes verification of compliance with requirements from validation of the
-  intended purpose in the intended environment. Preserve that distinction: `ACC`
-  actions validate stakeholder outcomes; the other right-side records verify specified
-  behavior or contracts.
-- [FDA General Principles of Software Validation](https://www.fda.gov/media/73141/download)
-  maps unit evidence to detailed design, integration evidence to high-level design, and
-  system evidence to software requirements; it also calls for objective pass/fail
-  records and traceability in both directions. Use the mapping without implying that
-  ordinary repositories are medical-device submissions.
-- [ECSS-E-ST-40C Rev.1](https://ecss.nl/standard/ecss-e-st-40c-rev-1-software-30-april-2025/)
-  emphasizes tailoring, early verification/validation planning, requirements-to-design
-  traceability, controlled evidence, and risk-scaled independence. Use only these
-  selected practices.
+- Turn a rough project prompt into a developer-confirmed design whose contracts and
+  acceptance criteria let independent agents build a coherent first version.
+- Compare a whole existing codebase with developer-confirmed goals to detect design
+  defects, missing or unintended behavior, and verification gaps.
 
-## Incremental V-model
+Store it under `.agents/v-model/` while the task is active. It may be committed on a task
+branch for coordination. Delete it when the initial implementation or holistic review
+is complete. Do not maintain it for routine feature work, releases, or later repository
+changes; persistent parallel specifications create avoidable synchronization work and
+eventually drift from the implementation.
 
-Do not run the profile as a single-pass waterfall. For each feature, defect correction,
-compatibility change, or release:
-
-1. Identify affected stakeholder outcomes and system requirements.
-2. Update logical contracts without encoding chosen file/package topology.
-3. Plan or revise right-side actions while writing the left-side records.
-4. Implement at the bottom of the V.
-5. Execute unit/inspection, integration, system, and acceptance evidence as applicable.
-6. Update current status, durable evidence, nonconformance, and regression impact.
-
-Baseline records incrementally after developer confirmation. A change to a baselined
-product gets its own mini-V and regression analysis.
+This is a repository-neutral V-profile, not a claim of NASA, FDA, ECSS, V-Modell XT, or
+regulated-lifecycle compliance. It uses the distinction between validating intended
+outcomes and verifying specified behavior, objective pass/fail records, bidirectional
+traceability, early evidence planning, tailoring, and risk-scaled independence.
 
 ## Four specification layers
 
 | Layer | Include | Exclude | Right side |
 | --- | --- | --- | --- |
-| `STK-###` stakeholder outcomes | Actors, operational scenarios, intended outcomes, success measures, explicit exclusions | Package names, file layout, algorithms | `ACC-###` operational validation and acceptance |
-| `SYS-###` system requirements | Observable capabilities, quality attributes, constraints, external boundaries, objective acceptance criteria | Internal architecture unless externally observable | `SYSV-###` black-box system verification |
-| `SUB-###` subsystem/interface contracts | Logical responsibilities, data/state/error semantics, boundary contracts | Chosen package and file topology | `INTV-###` integration, contract, and failure-path verification |
-| `CMP-###` component contracts | Non-obvious behavior, invariants, pre/postconditions, resource budgets needed to implement or verify | Exhaustive function documentation and obvious behavior | `UNITV-###` unit, property, static-analysis, or inspection evidence |
+| `STK-###` stakeholder outcomes | Actors, operational scenarios, intended outcomes, success measures, exclusions | Package names, file layout, algorithms | `ACC-###` operational validation and acceptance |
+| `SYS-###` system requirements | Observable capabilities, quality attributes, constraints, external boundaries, objective criteria | Internal architecture unless externally observable | `SYSV-###` black-box system verification |
+| `SUB-###` subsystem/interface contracts | Logical responsibilities, data, state, error, and boundary semantics | Chosen package and file topology | `INTV-###` integration and contract verification |
+| `CMP-###` component contracts | Non-obvious invariants, preconditions, postconditions, and resource budgets | Exhaustive function documentation and obvious behavior | `UNITV-###` unit, property, analysis, or inspection evidence |
 
 Parent layers are strict: `STK` has no parent; `SYS` points to `STK`; `SUB` points to
 `SYS`; `CMP` points to `SUB`. Use multiple parents when one record refines several
-concerns. Keep IDs stable when wording changes; retire rather than reuse an ID.
+concerns. Keep IDs stable during the active task and never reuse retired IDs.
 
-## Specification record format
+For initial design, make `SUB` boundaries and shared contracts precise enough to assign
+nonoverlapping implementation work. For holistic review, use every layer to compare
+confirmed intent with actual behavior and evidence.
 
-Use a level-two or deeper heading and the exact required fields:
+## Specification records
+
+Use a level-two or deeper heading and these fields:
 
 ```markdown
 ## SYS-014 — Export results without data loss
@@ -74,23 +62,22 @@ Use a level-two or deeper heading and the exact required fields:
 - **Parents:** STK-003
 - **Acceptance criterion:** Given ..., when ..., then ...
 - **Verification:** SYSV-008 (test), SYSV-011 (analysis)
-- **Origin / risk:** Customer interview; medium data-loss risk
-- **Context:** [Persistence decision](../context/persistence.md)
+- **Origin / risk:** Developer interview; medium data-loss risk
+- **Context:** [Persistence design](../context/persistence.md)
 ```
 
-Required fields are `Normative statement`, `Parents`, `Acceptance criterion`, and
-`Verification`. `Origin / risk` and `Context` are optional. Put `None` in `Parents` only
-for `STK` records. Every verification mapping includes an action ID and one method in
-parentheses: `test`, `analysis`, `inspection`, or `demonstration`.
+`Normative statement`, `Parents`, `Acceptance criterion`, and `Verification` are
+required. `Origin / risk` and `Context` are optional. Use `None` in `Parents` only for
+`STK`. Every verification mapping includes an action ID and one method in parentheses:
+`test`, `analysis`, `inspection`, or `demonstration`.
 
-Write one independently testable normative statement per record. Make the acceptance
-criterion objective enough for a future agent to decide pass or fail. Avoid vague terms
-such as “fast,” “robust,” or “user-friendly” unless a measurable threshold or scenario
-defines them.
+Write one independently testable statement per record. Make its criterion objective
+enough for an agent to decide pass or fail. Replace words such as "fast," "robust," or
+"user-friendly" with thresholds or concrete scenarios.
 
-## Verification action format
+## Verification actions
 
-Store all right-side actions in `verification.md` or its shards:
+Store right-side actions in `verification.md` or its shards:
 
 ```markdown
 ## SYSV-008 — Verify lossless result export
@@ -105,79 +92,66 @@ Store all right-side actions in `verification.md` or its shards:
 - **Nonconformance:** None
 ```
 
-Every action requires all eight fields. Use statuses consistently:
+Every action requires all eight fields. Use these statuses:
 
 | Status | Meaning |
 | --- | --- |
-| `planned` | The full action is designed but its durable test, analysis, inspection, or demonstration is not yet implemented. |
-| `implemented` | A durable action artifact exists, but current full-criterion execution evidence is absent or incomplete. |
-| `passing` | Current durable evidence demonstrates every pass-criterion clause in the named environment. |
-| `failing` | Current evidence violates at least one pass-criterion clause. |
+| `planned` | The action is designed but its durable artifact is absent. |
+| `implemented` | The artifact exists but current full-criterion evidence is incomplete. |
+| `passing` | Current durable evidence demonstrates every criterion clause in the named environment. |
+| `failing` | Current evidence violates at least one clause. |
 | `blocked` | Execution cannot proceed; name the blocker and owner or trigger. |
-| `waived` | Authorized rationale accepts the missing or failing evidence; link the approval. |
+| `waived` | An authorized rationale accepts missing or failing evidence; link approval. |
 
-A `passing` action must name durable evidence: a committed test or report, stable
-CI/release record, analysis file, or inspection record. Do not use pasted logs or a claim
-such as “tested manually” as the only evidence.
-For an `implemented` inspection action, cite a durable checklist, review record, or
-automated check; the source file being inspected is not itself the inspection artifact.
+A `passing` action must cite durable evidence. Do not use pasted logs or "tested
+manually" as the only evidence. Match procedures, criteria, and evidence clause by
+clause. Split actions when one artifact does not exercise every condition. Use fixtures
+that distinguish ordering, direction, field identity, and branch behavior.
 
-Record a failing or blocked action honestly and link its nonconformance. A waiver needs
-an explicit rationale and approval anchor. One action may cover several specifications,
-and one specification may require several actions.
+## Traceability
 
-Match the action’s procedure and pass criterion to the cited evidence clause by clause.
-If a specification contains several conditions, either exercise every condition or split
-the evidence into separate actions. Never mark an action `passing` because adjacent
-behavior is tested, because source inspection suggests it should work, or because only
-one direction or entry point is covered. Use a separate `analysis` or `inspection`
-action for source evidence and record unexercised cases as nonconformance or planned
-work.
-Choose fixtures that can distinguish the claimed outcomes. Symmetric or identical
-inputs cannot establish ordering, direction, field identity, or correct branch routing
-when a swapped implementation would produce the same result.
+Maintain bidirectional many-to-many links inside the temporary V-model:
 
-## Traceability rules
-
-Maintain bidirectional many-to-many links:
-
-- Every specification lists at least one matching right-side action.
+- Every specification lists at least one matching action.
 - Every action lists at least one covered specification.
-- The action ID appears on both sides, and the method in the specification matches the
-  action’s `Method`.
+- IDs appear on both sides and declared methods match.
 - `ACC` covers only `STK`; `SYSV` only `SYS`; `INTV` only `SUB`; `UNITV` only `CMP`.
-- Parent references point to existing records in the immediately higher layer.
-- Regular context documents link back to related specification IDs.
-- Plan verification while specifying the behavior; do not postpone all right-side
-  design until implementation is complete.
+- Parent references point to the immediately higher layer.
+- Plan verification while specifying behavior.
 
-Traceability demonstrates coverage, not truth. Review whether a test actually exercises
-the criterion and whether the criterion represents developer intent.
+Traceability demonstrates coverage, not truth. Review whether evidence exercises the
+criterion and whether the criterion represents developer intent. Persistent context may
+be linked from V-model records, but must not depend on reverse links or IDs that become
+meaningless after deletion.
 
 ## Specification versus decisions
 
-The V-model must stand alone as a behavioral contract. Keep these outside it:
+Keep these outside the V-model and in persistent context when they remain useful:
 
 - Chosen language, framework, package, file, class, or database layout.
-- Current source-file locations and named CI jobs when the normative need is an API or
-  compatibility outcome.
-- Trade studies and rejected alternatives.
-- Build-tool choices and local development conventions.
-- Rationale that explains why one implementation was selected.
+- Current source paths, CI job names, build tools, and local conventions.
+- Trade studies, rejected alternatives, architecture rationale, and workflows.
 
-Link to one relevant topic per subsystem section when background helps. If an
-implementation decision becomes an externally observable invariant, promote only that
-invariant into a `SYS`, `SUB`, or `CMP` statement. Leave the decision and rationale in
-`.agents/context/`. State a compatibility result independently of the workflow or tool
-currently used to demonstrate it.
+If an implementation choice becomes externally observable, specify only its invariant
+and objective acceptance meaning. Keep the mechanism and rationale in context. In a
+holistic review, preserve conflicts rather than rewriting goals to match code.
 
 ## Risk tailoring
 
-Record origin and risk when it changes assurance. Increase specialist review,
-environment fidelity, failure injection, evidence durability, and reviewer independence
-for safety, security, privacy, destructive operations, financial impact, hard real-time
-budgets, broad compatibility promises, or externally consumed interfaces.
+Increase specialist review, environment fidelity, failure injection, evidence
+durability, and reviewer independence for safety, security, privacy, destructive
+operations, financial impact, hard real-time budgets, compatibility promises, or public
+interfaces. Keep low-risk projects proportional: a few precise records are better than
+one record per function.
 
-Keep low-risk tiny libraries proportional: a small number of precise records is better
-than one record per function. Tailoring may reduce ceremony, never the objective
-pass/fail meaning of a retained requirement.
+## Close the V-model
+
+Before completing the task:
+
+1. Reconcile confirmed goals with implementation and evidence.
+2. Put current usage, development workflows, architecture, and decisions in durable
+   agent context.
+3. Record remaining work as concise current gaps in context or the issue tracker,
+   without V-model IDs or copied trace tables.
+4. Remove every router link to `.agents/v-model/`.
+5. Delete `.agents/v-model/` and run the linter with `--v-model absent`.

--- a/document-repository-v-model/scripts/lint_repository_docs.py
+++ b/document-repository-v-model/scripts/lint_repository_docs.py
@@ -34,6 +34,8 @@ WORD_RE = re.compile(r"\b[\w'-]+\b", re.UNICODE)
 PLACEHOLDER_RE = re.compile(
     r"\{\{[^{}\n]+\}\}|<[A-Z][A-Z0-9_ -]{2,}>|\b(?:TODO|TBD|FIXME|CHANGEME)\b"
 )
+VMODEL_LOCAL_PATH_RE = re.compile(r"(?:^|/)\.agents/v-model(?:/|$)")
+VMODEL_MENTION_RE = re.compile(r"\bv[- ]model\b", re.IGNORECASE)
 
 LAYER_ENTRIES = {
     "01-stakeholder-outcomes": "STK",
@@ -47,6 +49,7 @@ EXPECTED_ACTION = {"STK": "ACC", "SYS": "SYSV", "SUB": "INTV", "CMP": "UNITV"}
 EXPECTED_SPEC = {value: key for key, value in EXPECTED_ACTION.items()}
 METHODS = {"test", "analysis", "inspection", "demonstration"}
 STATUSES = {"planned", "implemented", "passing", "failing", "blocked", "waived"}
+VMODEL_STATES = {"active", "absent"}
 
 SPEC_REQUIRED_FIELDS = {
     "normative statement",
@@ -175,11 +178,9 @@ CONTEXT_METADATA_FIELDS = {
     "do not open when",
     "related specification ids",
     "review when",
+    "known gaps",
 }
 H2_RE = re.compile(r"^\s{0,3}##(?:[ \t]+|$)")
-JUSTIFIED_CONTEXT_WITHOUT_SPEC_RE = re.compile(
-    r"^none\s+—\s+\S(?:.*\S)?$", re.IGNORECASE
-)
 
 
 class InputError(Exception):
@@ -276,9 +277,17 @@ def _normalized_paragraph(block: Sequence[tuple[int, str]]) -> str | None:
 
 
 class RepositoryDocsLinter:
-    def __init__(self, repository: Path, source_roots: Sequence[Path]) -> None:
+    def __init__(
+        self,
+        repository: Path,
+        source_roots: Sequence[Path],
+        v_model_state: str,
+    ) -> None:
         self.repository = repository.resolve()
         self.source_roots = [path.resolve() for path in source_roots]
+        if v_model_state not in VMODEL_STATES:
+            raise ValueError(f"invalid V-model state: {v_model_state}")
+        self.v_model_state = v_model_state
         self.errors: list[Finding] = []
         self.warnings: list[Finding] = []
         self._finding_keys: set[tuple[str, str, str, int | None, str]] = set()
@@ -340,16 +349,23 @@ class RepositoryDocsLinter:
         self._check_required_routers()
         document_files = self._document_files()
         self._check_links(document_files)
-        self._discover_profiles()
-        self._parse_records()
-        self._validate_record_locations()
-        self._validate_records()
+        if self.v_model_state == "active":
+            self._check_vmodel_routing()
+            self._discover_profiles()
+            self._check_profile_routing()
+            self._parse_records()
+            self._check_profile_record_coverage()
+            self._validate_record_locations()
+            self._validate_records()
+        else:
+            self._check_stale_vmodel_references(self._repository_markdown_files())
         self._check_context_topics()
         self._check_sizes(document_files)
         self._check_duplicate_paragraphs(document_files)
         self._check_artifacts()
         self._check_boundary_routers()
-        self._check_baselined_placeholders()
+        if self.v_model_state == "active":
+            self._check_baselined_placeholders()
         self.errors.sort(key=lambda item: (item.path, item.line or 0, item.code))
         self.warnings.sort(key=lambda item: (item.path, item.line or 0, item.code))
 
@@ -373,19 +389,31 @@ class RepositoryDocsLinter:
                 "missing_agents_router",
                 "required .agents/index.md router is missing",
             ),
-            (
-                self.repository / ".agents" / "v-model",
-                "directory",
-                "missing_vmodel_directory",
-                "required .agents/v-model directory is missing",
-            ),
-            (
-                self.repository / ".agents" / "v-model" / "index.md",
-                "file",
-                "missing_vmodel_router",
-                "required .agents/v-model/index.md router is missing",
-            ),
         ]
+        vmodel_root = self.repository / ".agents" / "v-model"
+        if self.v_model_state == "active":
+            required.extend(
+                [
+                    (
+                        vmodel_root,
+                        "directory",
+                        "missing_vmodel_directory",
+                        "active mode requires .agents/v-model",
+                    ),
+                    (
+                        vmodel_root / "index.md",
+                        "file",
+                        "missing_vmodel_router",
+                        "active mode requires .agents/v-model/index.md",
+                    ),
+                ]
+            )
+        elif vmodel_root.exists() or vmodel_root.is_symlink():
+            self.error(
+                "unexpected_vmodel",
+                vmodel_root,
+                "absent mode requires .agents/v-model to be deleted",
+            )
         for path, expected_type, code, message in required:
             valid = path.is_file() if expected_type == "file" else path.is_dir()
             if not valid:
@@ -408,12 +436,133 @@ class RepositoryDocsLinter:
         agents_directory = self.repository / ".agents"
         if agents_directory.is_dir():
             try:
+                vmodel_root = agents_directory / "v-model"
                 files.update(
-                    path for path in agents_directory.rglob("*.md") if path.is_file()
+                    path
+                    for path in agents_directory.rglob("*.md")
+                    if path.is_file()
+                    and not (
+                        self.v_model_state == "absent"
+                        and (path == vmodel_root or vmodel_root in path.parents)
+                    )
                 )
             except OSError as exc:
                 raise InputError(f"cannot inspect {agents_directory}: {exc}") from exc
         return sorted(files)
+
+    def _repository_markdown_files(self) -> list[Path]:
+        files: list[Path] = []
+        vmodel_root = self.repository / ".agents" / "v-model"
+        for directory, names, filenames in os.walk(self.repository, followlinks=False):
+            names[:] = [name for name in names if name not in SKIPPED_DIRS]
+            path = Path(directory)
+            if self.v_model_state == "absent" and (
+                path == vmodel_root or vmodel_root in path.parents
+            ):
+                names[:] = []
+                continue
+            files.extend(
+                path / filename
+                for filename in filenames
+                if Path(filename).suffix.lower() == ".md"
+            )
+        return sorted(files)
+
+    def _check_stale_vmodel_references(self, files: Iterable[Path]) -> None:
+        external_schemes = {"data", "ftp", "http", "https", "mailto", "tel"}
+        agents_root = (self.repository / ".agents").resolve()
+        vmodel_root = (self.repository / ".agents" / "v-model").resolve()
+        for path in files:
+            lines = _visible_lines(self._read(path))
+            has_stale_link = False
+            stale_link_lines: set[int] = set()
+            for line_number, line in enumerate(lines, 1):
+                destinations = [match.group(1) for match in LINK_RE.finditer(line)]
+                reference_match = REFERENCE_LINK_RE.match(line)
+                if reference_match:
+                    destinations.append(reference_match.group(1))
+                stale_destinations: set[str] = set()
+                for raw_destination in destinations:
+                    raw = raw_destination.strip()
+                    if raw.startswith("<") and raw.endswith(">"):
+                        destination = raw[1:-1].strip()
+                    else:
+                        destination = raw.split(maxsplit=1)[0]
+                    try:
+                        parsed = urlsplit(destination)
+                    except ValueError:
+                        continue
+                    if parsed.scheme.lower() in external_schemes or parsed.netloc:
+                        continue
+                    local_path = unquote(parsed.path).replace("\\", "/")
+                    if local_path.startswith("/"):
+                        candidate = self.repository / local_path.lstrip("/")
+                    else:
+                        candidate = path.parent / local_path
+                    if VMODEL_LOCAL_PATH_RE.search(local_path) or _is_within(
+                        candidate.resolve(strict=False), vmodel_root
+                    ):
+                        stale_destinations.add(destination)
+                if stale_destinations:
+                    self.error(
+                        "stale_vmodel_link",
+                        path,
+                        "absent mode found link(s) to the temporary V-model: "
+                        + ", ".join(sorted(stale_destinations)),
+                        line_number,
+                    )
+                    has_stale_link = True
+                    stale_link_lines.add(line_number)
+
+            has_vmodel_context = has_stale_link or any(
+                VMODEL_MENTION_RE.search(line) for line in lines
+            )
+            resolved = path.resolve()
+            is_agent_document = path.name == "AGENTS.md" or _is_within(
+                resolved, agents_root
+            )
+            for line_number, line in enumerate(lines, 1):
+                identifiers = sorted(set(VALID_ID_FIND_RE.findall(line)))
+                if not identifiers:
+                    continue
+                field_match = FIELD_RE.match(line)
+                is_related_metadata = (
+                    field_match is not None
+                    and _normalize_field(field_match.group(1))
+                    == "related specification ids"
+                )
+                message = ", ".join(identifiers)
+                if line_number in stale_link_lines or is_related_metadata:
+                    self.error(
+                        "stale_vmodel_id",
+                        path,
+                        "absent mode found temporary V-model ID(s): "
+                        + message
+                        + "; replace them with current prose or an issue link",
+                        line_number,
+                    )
+                elif is_agent_document or has_vmodel_context:
+                    self.warn(
+                        "possible_stale_vmodel_id",
+                        path,
+                        "absent mode found possible temporary V-model ID(s): "
+                        + message
+                        + "; confirm their provenance",
+                        line_number,
+                    )
+
+    def _check_vmodel_routing(self) -> None:
+        root_index = self.repository / ".agents" / "index.md"
+        vmodel_index = self.repository / ".agents" / "v-model" / "index.md"
+        if not root_index.is_file() or not vmodel_index.is_file():
+            return
+        if vmodel_index.resolve() not in self._linked_local_files(root_index):
+            self.error(
+                "unrouted_vmodel",
+                root_index,
+                "active mode requires .agents/index.md to link directly to "
+                ".agents/v-model/index.md",
+            )
 
     def _check_links(self, files: Iterable[Path]) -> None:
         external_schemes = {"data", "ftp", "http", "https", "mailto", "tel"}
@@ -552,6 +701,59 @@ class RepositoryDocsLinter:
             status = self._profile_status(index) if index.is_file() else None
             self.profiles.append(Profile(profile_root.resolve(), files, status))
 
+    def _check_profile_routing(self) -> None:
+        vmodel_root = (self.repository / ".agents" / "v-model").resolve()
+        vmodel_index = vmodel_root / "index.md"
+        root_targets = (
+            self._linked_local_files(vmodel_index) if vmodel_index.is_file() else set()
+        )
+        for profile in self.profiles:
+            index = profile.root / "index.md"
+            if not index.is_file():
+                continue
+            if profile.root != vmodel_root and index.resolve() not in root_targets:
+                self.error(
+                    "unrouted_vmodel_profile",
+                    vmodel_index,
+                    ".agents/v-model/index.md must link directly to active product "
+                    f"profile {self._relative(index)}",
+                )
+            targets = self._linked_local_files(index)
+            for entry in LAYER_ENTRIES:
+                file_path = profile.root / f"{entry}.md"
+                directory_index = profile.root / entry / "index.md"
+                if file_path.is_file():
+                    target = file_path.resolve()
+                elif directory_index.is_file():
+                    target = directory_index.resolve()
+                else:
+                    continue
+                if target not in targets:
+                    self.error(
+                        "unrouted_profile_layer",
+                        index,
+                        f"profile index must link directly to {self._relative(target)}",
+                    )
+                if not directory_index.is_file():
+                    continue
+                layer_root = directory_index.parent.resolve()
+                layer_targets = self._linked_local_files(directory_index)
+                shards = sorted(
+                    path
+                    for path in profile.files
+                    if path != directory_index.resolve()
+                    and _is_within(path, layer_root)
+                    and path.suffix.lower() == ".md"
+                )
+                for shard in shards:
+                    if shard not in layer_targets:
+                        self.error(
+                            "unrouted_layer_shard",
+                            directory_index,
+                            "layer index must link directly to "
+                            f"{self._relative(shard)}",
+                        )
+
     def _profile_status(self, index: Path) -> str | None:
         pattern = re.compile(
             r"^\s*[-*]\s+\*\*Profile status:\*\*\s*(.+?)\s*$", re.IGNORECASE
@@ -681,6 +883,27 @@ class RepositoryDocsLinter:
                 values.append(line)
         flush()
         return fields, field_lines
+
+    def _check_profile_record_coverage(self) -> None:
+        for profile in self.profiles:
+            prefixes = {
+                record.prefix for record in self.records if record.path in profile.files
+            }
+            for entry, category in LAYER_ENTRIES.items():
+                expected_prefixes = (
+                    set(ACTION_PREFIXES) if category == "ACTION" else {category}
+                )
+                if prefixes & expected_prefixes:
+                    continue
+                file_path = profile.root / f"{entry}.md"
+                directory_path = profile.root / entry
+                target = directory_path if directory_path.is_dir() else file_path
+                label = "verification action" if category == "ACTION" else category
+                self.error(
+                    "empty_profile_layer",
+                    target,
+                    f"active profile requires at least one {label} record",
+                )
 
     def _validate_record_locations(self) -> None:
         for record in self.records:
@@ -1021,28 +1244,31 @@ class RepositoryDocsLinter:
             lines = _visible_lines(self._read(topic))
             metadata = self._context_metadata(lines)
             self._check_context_metadata(topic, metadata)
+            if self.v_model_state == "absent":
+                for line_number, _ in metadata.get("related specification ids", []):
+                    self.warn(
+                        "stale_vmodel_metadata",
+                        topic,
+                        "absent mode found Related specification IDs metadata; "
+                        "replace it with a concise Known gaps entry when needed",
+                        line_number,
+                    )
             text = "\n".join(lines)
             specification_ids = {
                 identifier
                 for identifier in VALID_ID_FIND_RE.findall(text)
                 if identifier.split("-", 1)[0] in SPEC_PREFIXES
             }
-            if not specification_ids and not self._has_justified_missing_specification(
-                metadata
-            ):
-                self.warn(
-                    "context_without_specification",
-                    topic,
-                    "context topic does not link to a specification ID",
-                )
-            for identifier in sorted(specification_ids):
-                record = self.records_by_id.get(identifier)
-                if record is None or record.prefix not in SPEC_PREFIXES:
-                    self.warn(
-                        "context_unknown_specification",
-                        topic,
-                        f"context topic references missing specification {identifier}",
-                    )
+            if self.v_model_state == "active":
+                for identifier in sorted(specification_ids):
+                    record = self.records_by_id.get(identifier)
+                    if record is None or record.prefix not in SPEC_PREFIXES:
+                        self.warn(
+                            "context_unknown_specification",
+                            topic,
+                            "context topic references missing specification "
+                            f"{identifier}",
+                        )
             if topic.resolve() not in reachable_topics:
                 self.warn(
                     "unreachable_context_topic",
@@ -1113,11 +1339,6 @@ class RepositoryDocsLinter:
                 "missing_context_do_not_open_when",
                 "Do not open when",
             ),
-            (
-                "related specification ids",
-                "missing_context_related_specification_ids",
-                "Related specification IDs",
-            ),
             ("review when", "missing_context_review_when", "Review when"),
         ):
             entries = metadata.get(field, [])
@@ -1129,18 +1350,6 @@ class RepositoryDocsLinter:
                     "level-two heading",
                     entries[0][0] if entries else None,
                 )
-
-    @staticmethod
-    def _has_justified_missing_specification(
-        metadata: dict[str, list[tuple[int, str]]],
-    ) -> bool:
-        return any(
-            JUSTIFIED_CONTEXT_WITHOUT_SPEC_RE.fullmatch(
-                value.strip().strip("`*_").strip()
-            )
-            is not None
-            for _, value in metadata.get("related specification ids", [])
-        )
 
     def _reachable_context_topics(self, context_root: Path) -> set[Path]:
         root_index = self.repository / ".agents" / "index.md"
@@ -1381,6 +1590,7 @@ class RepositoryDocsLinter:
         return {
             "repository": str(self.repository),
             "source_roots": [self._relative(path) for path in self.source_roots],
+            "v_model": self.v_model_state,
             "errors": [finding.as_dict() for finding in self.errors],
             "warnings": [finding.as_dict() for finding in self.warnings],
             "summary": {
@@ -1418,6 +1628,7 @@ def _resolve_source_roots(repository: Path, values: Sequence[str] | None) -> lis
 
 def _print_human(result: dict[str, object]) -> None:
     print(f"Repository: {result['repository']}")
+    print(f"V-model: {result['v_model']}")
     for group_name in ("errors", "warnings"):
         findings = result[group_name]
         assert isinstance(findings, list)
@@ -1442,6 +1653,15 @@ def build_parser() -> argparse.ArgumentParser:
         )
     )
     parser.add_argument("repository", help="repository root to inspect")
+    parser.add_argument(
+        "--v-model",
+        choices=sorted(VMODEL_STATES),
+        required=True,
+        help=(
+            "active requires, routes, and validates .agents/v-model; "
+            "absent rejects it and stale Markdown references"
+        ),
+    )
     parser.add_argument(
         "--source-root",
         action="append",
@@ -1468,7 +1688,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     repository = repository.resolve()
     try:
         source_roots = _resolve_source_roots(repository, args.source_root)
-        linter = RepositoryDocsLinter(repository, source_roots)
+        linter = RepositoryDocsLinter(repository, source_roots, args.v_model)
         linter.run()
         result = linter.result(args.fail_on_warn)
     except InputError as exc:

--- a/document-repository-v-model/scripts/test_lint_repository_docs.py
+++ b/document-repository-v-model/scripts/test_lint_repository_docs.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Regression tests for V-model lifecycle modes."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from io import StringIO
+from pathlib import Path
+
+SCRIPT_DIRECTORY = Path(__file__).resolve().parent
+if str(SCRIPT_DIRECTORY) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIRECTORY))
+
+from lint_repository_docs import RepositoryDocsLinter, build_parser
+
+
+class RepositoryDocsLinterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.repository = Path(self.temporary_directory.name)
+        self._write("AGENTS.md", "# Repository Guidance\n")
+        self._write(
+            ".agents/index.md",
+            "# Agent Context\n\n"
+            "- [Overview](context/overview.md) — open for repository facts.\n",
+        )
+        self._write(
+            ".agents/context/overview.md",
+            "# Overview\n\n"
+            "- **Context need:** Reference\n"
+            "- **Open when:** Looking up repository facts.\n"
+            "- **Do not open when:** No repository context is needed.\n"
+            "- **Review when:** Repository structure changes.\n"
+            "- **Known gaps:** None\n\n"
+            "## Facts\n\n"
+            "The fixture has durable agent documentation.\n",
+        )
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def _write(self, relative_path: str, content: str) -> None:
+        path = self.repository / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def _lint(self, state: str) -> RepositoryDocsLinter:
+        linter = RepositoryDocsLinter(self.repository, [], state)
+        linter.run()
+        return linter
+
+    def _add_complete_vmodel(self) -> None:
+        index = self.repository / ".agents/index.md"
+        index.write_text(
+            index.read_text(encoding="utf-8")
+            + "- [Active design](v-model/index.md) — open during the active task.\n",
+            encoding="utf-8",
+        )
+        self._write(
+            ".agents/v-model/index.md",
+            "# Product V-Model\n\n"
+            "- **Profile status:** draft\n\n"
+            "1. [Stakeholder outcomes](01-stakeholder-outcomes.md)\n"
+            "2. [System requirements](02-system-requirements.md)\n"
+            "3. [Subsystem contracts](03-subsystem-contracts.md)\n"
+            "4. [Component contracts](04-component-contracts.md)\n"
+            "5. [Verification](verification.md)\n",
+        )
+        specifications = {
+            "01-stakeholder-outcomes.md": (
+                "STK-001",
+                "None",
+                "ACC-001 (demonstration)",
+            ),
+            "02-system-requirements.md": ("SYS-001", "STK-001", "SYSV-001 (test)"),
+            "03-subsystem-contracts.md": ("SUB-001", "SYS-001", "INTV-001 (test)"),
+            "04-component-contracts.md": ("CMP-001", "SUB-001", "UNITV-001 (analysis)"),
+        }
+        for filename, (identifier, parents, verification) in specifications.items():
+            self._write(
+                f".agents/v-model/{filename}",
+                f"# Layer\n\n## {identifier} — Requirement\n\n"
+                "- **Normative statement:** The product shall behave as specified.\n"
+                f"- **Parents:** {parents}\n"
+                "- **Acceptance criterion:** The stated behavior is observed.\n"
+                f"- **Verification:** {verification}\n",
+            )
+
+        actions = (
+            ("ACC-001", "STK-001", "demonstration"),
+            ("SYSV-001", "SYS-001", "test"),
+            ("INTV-001", "SUB-001", "test"),
+            ("UNITV-001", "CMP-001", "analysis"),
+        )
+        records = ["# Verification\n"]
+        for action, specification, method in actions:
+            records.append(
+                f"## {action} — Check\n\n"
+                f"- **Covers:** {specification}\n"
+                f"- **Method:** {method}\n"
+                "- **Procedure:** Exercise the requirement.\n"
+                "- **Environment / configuration:** Test fixture.\n"
+                "- **Pass criterion:** The requirement is satisfied.\n"
+                "- **Status:** planned\n"
+                "- **Evidence:** None\n"
+                "- **Nonconformance:** None\n"
+            )
+        self._write(".agents/v-model/verification.md", "\n".join(records))
+
+    def test_absent_mode_accepts_durable_docs_without_vmodel(self) -> None:
+        linter = self._lint("absent")
+
+        self.assertEqual([], linter.errors)
+        self.assertEqual([], linter.warnings)
+
+    def test_active_mode_requires_vmodel(self) -> None:
+        linter = self._lint("active")
+
+        self.assertEqual(
+            {"missing_vmodel_directory", "missing_vmodel_router"},
+            {finding.code for finding in linter.errors},
+        )
+
+    def test_active_mode_validates_complete_vmodel(self) -> None:
+        self._add_complete_vmodel()
+
+        linter = self._lint("active")
+
+        self.assertEqual([], linter.errors)
+        self.assertEqual([], linter.warnings)
+
+    def test_active_mode_rejects_empty_profile_layers(self) -> None:
+        self._add_complete_vmodel()
+        for filename in (
+            "01-stakeholder-outcomes.md",
+            "02-system-requirements.md",
+            "03-subsystem-contracts.md",
+            "04-component-contracts.md",
+            "verification.md",
+        ):
+            self._write(f".agents/v-model/{filename}", "# Empty layer\n")
+
+        linter = self._lint("active")
+
+        self.assertEqual(
+            ["empty_profile_layer"] * 5,
+            [finding.code for finding in linter.errors],
+        )
+
+    def test_active_mode_requires_vmodel_route(self) -> None:
+        self._add_complete_vmodel()
+        index = self.repository / ".agents/index.md"
+        index.write_text(
+            "\n".join(
+                line
+                for line in index.read_text(encoding="utf-8").splitlines()
+                if "v-model/index.md" not in line
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        linter = self._lint("active")
+
+        self.assertEqual(
+            ["unrouted_vmodel"],
+            [finding.code for finding in linter.errors],
+        )
+
+    def test_active_mode_requires_layer_routes(self) -> None:
+        self._add_complete_vmodel()
+        index = self.repository / ".agents/v-model/index.md"
+        index.write_text(
+            "\n".join(
+                line
+                for line in index.read_text(encoding="utf-8").splitlines()
+                if "verification.md" not in line
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        linter = self._lint("active")
+
+        self.assertEqual(
+            ["unrouted_profile_layer"],
+            [finding.code for finding in linter.errors],
+        )
+
+    def test_active_mode_requires_shard_routes(self) -> None:
+        self._add_complete_vmodel()
+        layer_file = self.repository / ".agents/v-model/03-subsystem-contracts.md"
+        layer_content = layer_file.read_text(encoding="utf-8")
+        layer_file.unlink()
+        self._write(
+            ".agents/v-model/03-subsystem-contracts/index.md",
+            "# Subsystem contracts\n",
+        )
+        self._write(
+            ".agents/v-model/03-subsystem-contracts/storage.md",
+            layer_content,
+        )
+        index = self.repository / ".agents/v-model/index.md"
+        index.write_text(
+            index.read_text(encoding="utf-8").replace(
+                "03-subsystem-contracts.md",
+                "03-subsystem-contracts/index.md",
+            ),
+            encoding="utf-8",
+        )
+
+        linter = self._lint("active")
+
+        self.assertEqual(
+            ["unrouted_layer_shard"],
+            [finding.code for finding in linter.errors],
+        )
+
+    def test_cli_requires_explicit_vmodel_state(self) -> None:
+        with redirect_stderr(StringIO()), self.assertRaises(SystemExit) as raised:
+            build_parser().parse_args([str(self.repository)])
+
+        self.assertEqual(2, raised.exception.code)
+
+    def test_absent_mode_rejects_retained_vmodel(self) -> None:
+        self._add_complete_vmodel()
+
+        linter = self._lint("absent")
+
+        self.assertEqual(
+            ["stale_vmodel_link", "unexpected_vmodel"],
+            [finding.code for finding in linter.errors],
+        )
+
+    def test_absent_mode_flags_possible_orphaned_ids(self) -> None:
+        path = self.repository / ".agents/context/overview.md"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "- **Known gaps:** None", "- **Known gaps:** Finish SYS-001"
+            ),
+            encoding="utf-8",
+        )
+
+        linter = self._lint("absent")
+
+        self.assertEqual([], linter.errors)
+        self.assertEqual(
+            ["possible_stale_vmodel_id"],
+            [finding.code for finding in linter.warnings],
+        )
+
+    def test_absent_mode_checks_repository_markdown(self) -> None:
+        self._write(
+            "docs/design.md",
+            "# Design\n\n"
+            "Finish SYS-001, then read [the model](../.agents/v-model/index.md).\n",
+        )
+
+        linter = self._lint("absent")
+
+        self.assertEqual(
+            ["stale_vmodel_id", "stale_vmodel_link"],
+            [finding.code for finding in linter.errors],
+        )
+
+    def test_absent_mode_ignores_unrelated_ids_in_regular_docs(self) -> None:
+        self._write(
+            "docs/issues.md",
+            "# External issues\n\nTrack SYS-001, CMP-123, and ACC-001 here.\n",
+        )
+
+        linter = self._lint("absent")
+
+        self.assertEqual([], linter.errors)
+        self.assertEqual([], linter.warnings)
+
+    def test_absent_mode_does_not_reject_ambiguous_ids(self) -> None:
+        self._write(
+            "docs/issues.md",
+            "# V-model alternatives\n\nTrack unrelated ticket SYS-001 here.\n",
+        )
+
+        linter = self._lint("absent")
+
+        self.assertEqual([], linter.errors)
+        self.assertEqual(
+            ["possible_stale_vmodel_id"],
+            [finding.code for finding in linter.warnings],
+        )
+
+    def test_absent_mode_warns_about_vmodel_metadata(self) -> None:
+        path = self.repository / ".agents/context/overview.md"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "- **Known gaps:** None",
+                "- **Related specification IDs:** None — repository workflow",
+            ),
+            encoding="utf-8",
+        )
+
+        linter = self._lint("absent")
+
+        self.assertEqual([], linter.errors)
+        self.assertEqual(
+            ["stale_vmodel_metadata"],
+            [finding.code for finding in linter.warnings],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Limit V-model use to pre-code initial design and holistic codebase review, with developer interviews central to both workflows.
- Make AGENTS.md routers and .agents/context durable while requiring the temporary .agents/v-model tree to be removed at task completion.
- Add explicit active and absent linter modes, including active-profile routing and completeness checks plus final-state cleanup checks across repository Markdown.
- Add regression coverage for repositories with and without V-models, sharded profiles, stale references, and unrelated identifier patterns.

## Validation

- python3 -m unittest -v document-repository-v-model/scripts/test_lint_repository_docs.py (14 tests)
- skill-creator quick validation
- git diff --check
- clean-room initial-design and holistic-review workflow checks
- independent lifecycle/linter audits with final targeted recheck